### PR TITLE
Feature/conformant errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,14 @@ module.exports.getCount = (req, logger, context) => new Promise((resolve, reject
 - **Description:** Return the number of patients in your data store.
 - **Required:** Yes
 - **Return:** `Promise.<number, Error>`
+- **Routes:** Required for metadata and capability statement
 
 #### `getPatientById`
 
 - **Description:** Get the patient given an id in the req.params.
 - **Required:** Yes
 - **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `dstu2/patient/:id` via GET
 
 #### `getPatient`
 
@@ -290,6 +292,7 @@ module.exports.getCount = (req, logger, context) => new Promise((resolve, reject
 	- given + gender
 - **Required:** Yes
 - **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `/dstu2/patient` via GET and `/dstu2/patient/_search` via POST
 
 ### Observation
 
@@ -298,18 +301,21 @@ module.exports.getCount = (req, logger, context) => new Promise((resolve, reject
 - **Description:** Get the count of the number of observations.
 - **Required:** Yes
 - **Return:** `Promise.<number, Error>`
+- **Routes:** Required for metadata and capability statement
 
 #### `getObservation`
 
 - **Description:** TODO
 - **Required:** Yes
 - **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `/dstu2/observation` via GET and `/dstu2/observation/_search` via POST
 
 #### `getObservationById`
 
 - **Description:** TODO
 - **Required:** Yes
 - **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `dstu2/observation/:id` via GET
 
 ## Examples
 

--- a/src/__tests__/utils/auth.test.js
+++ b/src/__tests__/utils/auth.test.js
@@ -56,7 +56,7 @@ describe('Auth Utils Test', () => {
 
 	test('should not validate a request with an undecodable token', async () => {
 		await validateFn({ headers: { authorization: 'Bearer asdfasdfasdfa' } }, {}, mockNext);
-		expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(401, 'invalid_token'));
+		expect(mockNext.mock.calls[0][0]).toEqual(errors.unauthorized('Invalid token'));
 	});
 
 	test('should validate a request with a valid token with sufficient scopes in the token', async () => {
@@ -66,7 +66,7 @@ describe('Auth Utils Test', () => {
 
 	test('should not validate a request with a valid token with insufficient scopes', async () => {
 		await validateFn({ headers: { authorization: `Bearer ${validTokenWithInsufficientScopes}` } }, {}, mockNext);
-		expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(403, 'insufficient_scope'));
+		expect(mockNext.mock.calls[0][0]).toEqual(errors.insufficientScope());
 	});
 
 	// ***** Introspection test website is down at the moment ********
@@ -75,35 +75,35 @@ describe('Auth Utils Test', () => {
 	// 	config.introspection_endpoint = undefined;
 	// 	await validateFn({ headers: { authorization: `Bearer ${validTokenWithoutScopes}` } }, {}, mockNext);
 	// 	console.log(mockNext.mock.calls);
-	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(403, 'insufficient_scope'));
+	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.insufficientScope());
 	// });
 
 	// test('should not validate a request with a valid token but introspection endpoint fails', async () => {
 	// 	nock(introspection_endpoint).post('/').reply(500);
 
 	// 	await validateFn({ headers: { authorization: `Bearer ${validTokenWithoutScopes}` } }, {}, mockNext);
-	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(403, 'insufficient_scope'));
+	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.insufficientScope());
 	// });
 
 	// test('should not validate a request with a valid token but the token is not active', async () => {
 	// 	nock(introspection_endpoint).post('/').reply(200, { active: false, no_scope: true });
 
 	// 	await validateFn({ headers: { authorization: `Bearer ${validTokenWithoutScopes}` } }, {}, mockNext);
-	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(401, 'invalid_token'));
+	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.unauthorized('Invalid token'));
 	// });
 
 	// test('should not validate a request with a valid token but introspection endpoint does not return scope', async () => {
 	// 	nock(introspection_endpoint).post('/').reply(200, { active: true, no_scope: true });
 
 	// 	await validateFn({ headers: { authorization: `Bearer ${validTokenWithoutScopes}` } }, {}, mockNext);
-	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(403, 'insufficient_scope'));
+	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.insufficientScope());
 	// });
 
 	// test('should not validate a request with a valid token but introspection endpoint returns insufficient scope', async () => {
 	// 	nock(introspection_endpoint).post('/').reply(200, { active: true, scope: 'badscope' });
 
 	// 	await validateFn({ headers: { authorization: `Bearer ${validTokenWithoutScopes}` } }, {}, mockNext);
-	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.custom(403, 'insufficient_scope'));
+	// 	expect(mockNext.mock.calls[0][0]).toEqual(errors.insufficientScope());
 	// });
 
 	// test('should validate a request with a valid token and introspection endpoint returns a valid scope', async () => {

--- a/src/__tests__/utils/sanitize.test.js
+++ b/src/__tests__/utils/sanitize.test.js
@@ -2,6 +2,7 @@ const moment = require('moment');
 const path = require('path');
 const { sanitizeMiddleware } = require(path.resolve('./src/server/utils/sanitize.utils'));
 const errors = require(path.resolve('./src/server/utils/error.utils'));
+const OperationOutcome = require('../server/resources/OperationOutcome');
 
 const ARGS = [
 	{
@@ -137,7 +138,7 @@ describe('Sanitize Utils Tests', () => {
 		let nextArg = next.mock.calls[0][0];
 
 		expect(next).toHaveBeenCalled();
-		expect(nextArg).toBeInstanceOf(errors.ServerError);
+		expect(nextArg).toBeInstanceOf(OperationOutcome);
 		expect(nextArg.message).toEqual('Invalid parameter');
 	});
 
@@ -168,7 +169,7 @@ describe('Sanitize Utils Tests', () => {
 		let nextArg = next.mock.calls[0][0];
 
 		expect(next).toHaveBeenCalled();
-		expect(nextArg).toBeInstanceOf(errors.ServerError);
+		expect(nextArg).toBeInstanceOf(OperationOutcome);
 		expect(nextArg.message).toEqual('Invalid parameter');
 	});
 
@@ -184,7 +185,7 @@ describe('Sanitize Utils Tests', () => {
 		let nextArg = next.mock.calls[0][0];
 
 		expect(next).toHaveBeenCalled();
-		expect(nextArg).toBeInstanceOf(errors.ServerError);
+		expect(nextArg).toBeInstanceOf(OperationOutcome);
 		expect(nextArg.message).toEqual('Invalid parameter');
 	});
 
@@ -203,7 +204,7 @@ describe('Sanitize Utils Tests', () => {
 		let nextArg = next.mock.calls[0][0];
 
 		expect(next).toHaveBeenCalled();
-		expect(nextArg).toBeInstanceOf(errors.ServerError);
+		expect(nextArg).toBeInstanceOf(OperationOutcome);
 		expect(nextArg.message).toEqual('Invalid parameter');
 	});
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 exports.DSTU2 = {
 	RESOURCE_TYPES: {
+		OPERATIONOUTCOME: 'OperationOutcome',
 		CONFORMANCE: 'Conformance',
 		OBSERVATION: 'Observation',
 		PATIENT: 'Patient'
@@ -12,6 +13,56 @@ exports.DSTU2 = {
 	MODE: {
 		CONFIDENTIAL: 'confidential',
 		PUBLIC: 'public'
+	}
+};
+
+exports.ISSUE = {
+	SEVERITY: {
+		FATAL: 'fatal',
+		ERROR: 'error',
+		WARNING: 'warning',
+		INFO: 'information'
+	},
+	// Codes defined here: https://www.hl7.org/fhir/valueset-issue-type.html
+	CODE: {
+		// Invalid can be seen as a parent essentially to these, see Level on above url
+		// This means structure, required, value, and invariant, are all also invalid
+		// you can send invalid back or something more specific
+		INVALID: 'invalid',
+		STRUCTURE: 'structure',
+		REQUIRED: 'required',
+		VALUE: 'value',
+		INVARIANT: 'invariant',
+		// Security is parent of login, unknown, expired, forbidden, and surpressed
+		SECURITY: 'security',
+		LOGIN: 'login',
+		UNKNOWN: 'unknown',
+		EXPIRED: 'expired',
+		FORBIDDEN: 'forbidden',
+		SUPPRESSED: 'surpressed',
+		// Procesing has no parent/children
+		PROCESSING: 'processing',
+		// Not Supported is parent of duplicate, not found, and too long
+		NOT_SUPPORTED: 'not-supported',
+		DUPLICATE: 'duplicate',
+		NOT_FOUND: 'not-found',
+		TOO_LONG: 'too-long',
+		// Code invalid is parent of extension, too costly, business rule, conflict, and incomplete
+		CODE_INVALID: 'code-invalid',
+		EXTENSION: 'extension',
+		TOO_COSTLY: 'too-costly',
+		BUSINESS_RULE: 'business-rule',
+		CONFLICT: 'conflict',
+		INCOMPLETE: 'incomplete',
+		// Transient is parent of lock error, no store, exception, timeout, and throttled
+		TRANSIENT: 'transient',
+		LOCK_ERROR: 'lock-error',
+		NO_STORE: 'no-store',
+		EXCEPTION: 'exception',
+		TIMEOUT: 'timeout',
+		THROTTLED: 'throttled',
+		// Informational has no parent/children
+		INFORMATIONAL: 'informational'
 	}
 };
 

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -131,8 +131,8 @@ let setupErrorHandler = function (app, logger) {
 	app.use((err, req, res, next) => {
 		// If there is an error and it is our error type
 		if (err && errors.isServerError(err)) {
-			logger.error(err.code, err.message);
-			res.status(err.code).end(err.message);
+			logger.error(err.statusCode, err.message);
+			res.status(err.statusCode).end(err.message);
 		}
 		// If there is still an error, throw a 500 and pass the message through
 		else if (err) {
@@ -148,8 +148,8 @@ let setupErrorHandler = function (app, logger) {
 	// Nothing has responded by now, respond with 404
 	app.use((req, res) => {
 		let error = errors.notFound();
-		logger.error(error.code, error.message);
-		res.status(error.code).end(error.message);
+		logger.error(error.statusCode, error.message);
+		res.status(error.statusCode).end(error.message);
 	});
 };
 

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -169,7 +169,7 @@ module.exports.initialize = async ({ config, logger }) => {
 	let app = express();
 
 	// Setup auth configs for middleware
-	// await initAuthConfig(auth);
+	await initAuthConfig(auth);
 
 	// Add some configurations to our app
 	configureMiddleware(app, IS_PRODUCTION);

--- a/src/server/dstu2/metadata/controllers/metadata.controller.js
+++ b/src/server/dstu2/metadata/controllers/metadata.controller.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('../../../utils/error.utils');
+const errors = require('../../../utils/error.utils');
 const service = require('../services/metadata.service');
 
 /**
@@ -10,6 +10,6 @@ module.exports.getCapabilityStatement = (profiles, logger, security) => {
   return (req, res, next) => {
 		return service.generateCapabilityStatement(req, profiles, logger, security)
 			.then((statement) => res.status(200).json(statement))
-			.catch((err) => next(new ServerError(500, err.message)));
+			.catch((err) => next(errors.internal(err.message)));
 	};
 };

--- a/src/server/dstu2/observation/controllers/observation.controller.js
+++ b/src/server/dstu2/observation/controllers/observation.controller.js
@@ -42,7 +42,7 @@ module.exports.getObservations = (profile, logger) => {
 					}
 				}
 
-				res.send(searchResults);
+				res.status(200).json(searchResults);
 			})
 			.catch((err) => {
 				next(errors.internal(err.message));
@@ -69,9 +69,9 @@ module.exports.getObservationById = (profile, logger) => {
 		return service.getObservationById(req, logger, context)
 			.then((observation) => {
 				if (observation) {
-					res.send(observation);
+					res.status(200).json(observation);
 				} else {
-					res.status(404).end();
+					next(errors.notFound('Observation not found'));
 				}
 			})
 			.catch((err) => {

--- a/src/server/dstu2/observation/controllers/observation.controller.js
+++ b/src/server/dstu2/observation/controllers/observation.controller.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('../../../utils/error.utils');
+const errors = require('../../../utils/error.utils');
 const { VERSIONS } = require('../../../../constants');
 
 module.exports.getObservations = (profile, logger) => {
@@ -45,7 +45,7 @@ module.exports.getObservations = (profile, logger) => {
 				res.send(searchResults);
 			})
 			.catch((err) => {
-				next(new ServerError(500, err.message));
+				next(errors.internal(err.message));
 			});
 	};
 };
@@ -75,7 +75,7 @@ module.exports.getObservationByID = (profile, logger) => {
 				}
 			})
 			.catch((err) => {
-				next(new ServerError(500, err.message));
+				next(errors.internal(err.message));
 			});
 	};
 };

--- a/src/server/dstu2/patient/controllers/patient.controller.js
+++ b/src/server/dstu2/patient/controllers/patient.controller.js
@@ -42,7 +42,7 @@ module.exports.getPatient = (profile, logger) => {
 					}
 				}
 
-				res.send(searchResults);
+				res.status(200).json(searchResults);
 			})
 			.catch((err) => {
 				next(errors.internal(err.message));
@@ -71,9 +71,9 @@ module.exports.getPatientById = (profile, logger) => {
 		return service.getPatientById(req, logger, context)
 			.then((patient) => {
 				if (patient) {
-					res.send(patient);
+					res.status(200).json(patient);
 				} else {
-					res.status(404).end();
+					next(errors.notFound('Patient not found'));
 				}
 			})
 			.catch((err) => {

--- a/src/server/dstu2/patient/controllers/patient.controller.js
+++ b/src/server/dstu2/patient/controllers/patient.controller.js
@@ -1,4 +1,4 @@
-const { ServerError } = require('../../../utils/error.utils');
+const errors = require('../../../utils/error.utils');
 const { VERSIONS } = require('../../../../constants');
 
 module.exports.getPatient = (profile, logger) => {
@@ -45,7 +45,7 @@ module.exports.getPatient = (profile, logger) => {
 				res.send(searchResults);
 			})
 			.catch((err) => {
-				next(new ServerError(500, err.message));
+				next(errors.internal(err.message));
 			});
 	};
 
@@ -77,7 +77,7 @@ module.exports.getPatientById = (profile, logger) => {
 				}
 			})
 			.catch((err) => {
-				next(new ServerError(500, err.message));
+				next(errors.internal(err.message));
 			});
 	};
 };

--- a/src/server/resources/OperationOutcome.js
+++ b/src/server/resources/OperationOutcome.js
@@ -1,0 +1,57 @@
+const Issue = require('./types/Issue');
+const { DSTU2 } = require('../../constants');
+
+/* eslint-disable no-useless-escape */
+let div_content = (severity, message, diagnostics) =>
+	'<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\">'
+	+ `<table border=\"0\"><tr><td style=\"font-weight: bold;\">${severity}</td>`
+	+ `<td>${message}</td><td><pre>${diagnostics}</pre></td></tr></table></div>`;
+/* eslint-enable no-useless-escape */
+
+class OperationOutcome extends Error {
+
+	constructor(options) {
+		super(options.message || 'HTTP 500 Internal Server Error');
+
+		this._statusCode = options.statusCode || 500;
+		this._message = options.message || 'HTTP 500 Internal Server Error';
+		this._resourceType = DSTU2.RESOURCE_TYPES.OPERATIONOUTCOME;
+
+		// if the options are provided, pass them in to create a new issue
+		this._issue = options.code && options.severity ? new Issue(options) : {};
+	}
+
+	issue (options) {
+		this._issue = new Issue(options);
+	}
+
+	get message () {
+		return this._message;
+	}
+
+	set message (message) {
+		this._message = message;
+	}
+
+	get statusCode () {
+		return this._statusCode;
+	}
+
+	set statusCode (statusCode) {
+		this._statusCode = statusCode;
+	}
+
+	toJSON() {
+		return {
+			resourceType: this._resourceType,
+			text: {
+				status: 'generated',
+				div: div_content(this._severity, this._message, this._diagnostics)
+			},
+			issue: [this._issue]
+		};
+	}
+
+}
+
+module.exports = OperationOutcome;

--- a/src/server/resources/types/Attachment.js
+++ b/src/server/resources/types/Attachment.js
@@ -1,6 +1,8 @@
 const Code = require('./Code');
 const Element = require('./Element');
 
+console.log(Element);
+
 // Attachment	Σ I		Element	Content in a format defined elsewhere
 // It the Attachment has data, it SHALL have a contentType
 class Attachment extends Element {

--- a/src/server/resources/types/Issue.js
+++ b/src/server/resources/types/Issue.js
@@ -1,0 +1,98 @@
+const CodeableConcept = require('./CodeableConcept');
+const { ISSUE } = require('../../../constants');
+
+// If we do not understand the error severity, it's more than likely
+// an unexpected error and we will give it the highest severity
+let issueSeverity = severity => {
+	return Object.values(ISSUE.SEVERITY).indexOf(severity) === -1
+		? ISSUE.SEVERITY.FATAL
+		: severity;
+};
+
+// If we do not understand the error code, it's more than likely
+// an unexpected error and we will give it a generic processing code
+// See https://www.hl7.org/fhir/valueset-issue-type.html
+let issueType = code => {
+	return Object.values(ISSUE.CODE).indexOf(code) === -1
+		? ISSUE.CODE.PROCESSING
+		: code;
+};
+
+class Issue {
+
+	constructor(options) {
+		// Severity & Code are required
+		this._severity = issueSeverity(options.severity);
+		this._code = issueType(options.code);
+		// The rest are optional
+		this._details = new CodeableConcept(options.details);
+		this._diagnostics = options.diagnostics;
+		this._expression = options.expression;
+		this._location = options.location;
+	}
+
+	get severity () {
+		return this._severity;
+	}
+
+	set severity (severity) {
+		this._severity = issueSeverity(severity);
+	}
+
+	get code () {
+		return this._code;
+	}
+
+	set code (code) {
+		this._code = issueType(code);
+	}
+
+	get details () {
+		return this._details;
+	}
+
+	set details (details) {
+		this._details = new CodeableConcept(details);
+	}
+
+	get diagnostics () {
+		return this._diagnostics;
+	}
+
+	set diagnostics (diagnostics) {
+		this._diagnostics = diagnostics;
+	}
+
+	get expression () {
+		return this._expression;
+	}
+
+	set expression (expression) {
+		this._expression = expression;
+	}
+
+	get location () {
+		return this._location;
+	}
+
+	set location (location) {
+		this._location = location;
+	}
+
+	toJSON () {
+		let response = {
+			severity: this._severity,
+			code: this._code
+		};
+
+		if (this._diagnostics) { response.diagnostics = this._diagnostics; }
+		if (this._expression) { response.expression = this._expression; }
+		if (this._location) { response.location = this._location; }
+		if (this._details) { response.details = this._details; }
+
+		return response;
+	}
+
+}
+
+module.exports = Issue;

--- a/src/server/utils/auth.js
+++ b/src/server/utils/auth.js
@@ -80,13 +80,13 @@ async function _verifyToken(token, secretOrPublicKey, options = {}, validScopes,
 	} catch (err) {
 		// log error return 401 with error message;
 		logger.error(err, err.message);
-		return next(errors.custom(401, 'invalid_token'));
+		return next(errors.unauthorized('Invalid token'));
 	}
 
 	logger.debug('Token has been verified. Searching for scope ...');
 
 	if (typeof decoded.scope === 'string') {
-		return _hasCorrectScope(decoded, validScopes) ? next() : next(errors.custom(403, 'insufficient_scope'));
+		return _hasCorrectScope(decoded, validScopes) ? next() : next(errors.insufficientScope());
 	} else if (oauthConfig.introspection_endpoint) {
 		logger.debug('Attempting to introspect token');
 
@@ -105,21 +105,21 @@ async function _verifyToken(token, secretOrPublicKey, options = {}, validScopes,
 			logger.debug('Successfully introspected token');
 			if (!introspection.active) {
 				logger.error('Access token is not active');
-				return next(errors.custom(401, 'invalid_token'));
+				return next(errors.unauthorized('Invalid token'));
 			} else if (!_hasCorrectScope(introspection, validScopes)) {
 				logger.error('Access token has insufficient scope');
-				return next(errors.custom(403, 'insufficient_scope'));
+				return next(errors.insufficientScope());
 			} else {
 				logger.info('Access token and scope have been verified');
 				return next();
 			}
 		} catch (error) {
 			logger.error(`Failed to introspect token ${error}`);
-			return next(errors.custom(403, 'insufficient_scope'));
+			return next(errors.insufficientScope());
 		}
 	} else {
 		logger.error('The scope of the token is insufficient or the token cannot be introspected');
-		return next(errors.custom(403, 'insufficient_scope'));
+		return next(errors.insufficientScope());
 	}
 }
 
@@ -161,7 +161,7 @@ module.exports.validate = (validScopes, loggerUtil, config) => {
 					}
 				} else {
 					// invalid bearer token
-					return next(errors.custom(401, 'invalid_token'));
+					return next(errors.unauthorized('Invalid token'));
 				}
 			} else {
 				// did not pass checks, return 401 message
@@ -171,5 +171,3 @@ module.exports.validate = (validScopes, loggerUtil, config) => {
 		}
 	};
 };
-
-

--- a/src/server/utils/error.utils.js
+++ b/src/server/utils/error.utils.js
@@ -1,18 +1,79 @@
-/**
- * @class ServerError
- * @summary Extends error to add additional code property
- */
-class ServerError extends Error {
-  constructor (code, message) {
-    super(message);
+const OperationOutcome = require('../resources/OperationOutcome');
+const { ISSUE } = require('../../constants');
 
-    if (Error.captureStackStrace) {
-      Error.captureStackStrace(this, ServerError);
-    }
+// /**
+//  * @class ServerError
+//  * @summary Extends error to add additional code property
+//  */
+// class ServerError extends Error {
+//   constructor (code, message) {
+//     super(message);
+//
+//     if (Error.captureStackStrace) {
+//       Error.captureStackStrace(this, ServerError);
+//     }
+//
+//     this.code = code;
+//   }
+// }
 
-    this.code = code;
-  }
-}
+// Invalid or Missing parameter from request
+let invalidParameter = message =>
+	new OperationOutcome({
+		statusCode: 400,
+		code: ISSUE.CODE.INVALID,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message,
+		message
+	});
+
+// Unauthorized request of some resource
+let unauthorized = message =>
+	new OperationOutcome({
+		statusCode: 401,
+		code: ISSUE.CODE.FORBIDDEN,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message || 'Unauthorized request',
+		message: message || 'Unauthorized request'
+	});
+
+let insufficientScope = message =>
+	new OperationOutcome({
+		statusCode: 403,
+		code: ISSUE.CODE.FORBIDDEN,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message || 'Insufficient scope',
+		message: message || 'Insufficient scope'
+	});
+
+let notFound = message =>
+	new OperationOutcome({
+		statusCode: 404,
+		code: ISSUE.CODE.NOT_FOUND,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message || 'Not found',
+		message: message || 'Not found'
+	});
+
+let deleted = message =>
+	new OperationOutcome({
+		statusCode: 410,
+		code: ISSUE.CODE.NOT_FOUND,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message || 'Resource deleted',
+		message: message || 'Resource deleted'
+	});
+
+let internal = message =>
+	new OperationOutcome({
+		statusCode: 500,
+		code: ISSUE.CODE.EXCEPTION,
+		severity: ISSUE.SEVERITY.ERROR,
+		diagnostics: message || 'Internal server error',
+		message: message || 'Internal server error'
+	});
+
+let isServerError = err => err instanceof OperationOutcome;
 
 /**
  * @name exports
@@ -20,12 +81,12 @@ class ServerError extends Error {
  * @summary Error Configurations
  */
 module.exports = {
-  invalidParameter: () => new ServerError(400, 'Invalid parameter'),
-  unauthorized: () => new ServerError(401, 'Unauthorized request'),
-  insufficientScope: () => new ServerError(403, 'Insufficient scope'),
-  notFound: () => new ServerError(404, 'Not found'),
-  deleted: () => new ServerError(410, 'Resource deleted'),
-  custom: (code, message) => new ServerError(code, message),
-  isServerError: (err) => err instanceof ServerError,
-	ServerError: ServerError
+  invalidParameter,
+  unauthorized,
+  insufficientScope,
+  notFound,
+  deleted,
+	internal,
+  isServerError
+	// ServerError
 };

--- a/src/server/utils/error.utils.js
+++ b/src/server/utils/error.utils.js
@@ -81,12 +81,12 @@ let isServerError = err => err instanceof OperationOutcome;
  * @summary Error Configurations
  */
 module.exports = {
-  invalidParameter,
-  unauthorized,
-  insufficientScope,
-  notFound,
-  deleted,
+	invalidParameter,
+	unauthorized,
+	insufficientScope,
+	notFound,
+	deleted,
 	internal,
-  isServerError
+	isServerError
 	// ServerError
 };


### PR DESCRIPTION
Added appropriate errors for all the types of errors we currently support.

Example of a Invalid Token Error, It sends back a 401 with the following json

```json
{
  "resourceType": "OperationOutcome",
  "text": {
    "status": "generated",
    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><table border=\"0\"><tr><td style=\"font-weight: bold;\">error</td><td><pre>Invalid token</pre></td></tr></table></div>"
  },
  "issue": [
    {
      "severity": "error",
      "code": "forbidden",
      "diagnostics": "Invalid token"
    }
  ]
}
```