### PR TITLE
Adding boilerplate for stu3 capability statement

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,25 @@ exports.DSTU2 = {
 	}
 };
 
+exports.STU3 = {
+	RESOURCE_TYPES: {
+		OPERATIONOUTCOME: 'OperationOutcome',
+		CONFORMANCE: 'CapabilityStatement',
+		OBSERVATION: 'Observation',
+		PATIENT: 'Patient'
+	},
+	STATUSES: {
+		DRAFT: 'draft',
+		ACTIVE: 'active',
+		RETIRED: 'retired'
+	},
+	MODE: {
+		CONFIDENTIAL: 'confidential',
+		PUBLIC: 'public'
+	}
+};
+
+
 exports.ISSUE = {
 	SEVERITY: {
 		FATAL: 'fatal',

--- a/src/server/stu3/metadata/capability.js
+++ b/src/server/stu3/metadata/capability.js
@@ -1,0 +1,49 @@
+const moment = require('moment-timezone');
+const { STU3 } = require('../../../constants');
+
+/**
+ * @name exports
+ * @summary Capability statement shell
+ */
+module.exports.makeStatement = resources => ({
+	resourceType: STU3.RESOURCE_TYPES.CONFORMANCE,
+	status: STU3.STATUSES.DRAFT,
+	date: moment().tz('America/New_York').format(),
+	publisher: 'Not provided',
+	kind: 'instance',
+	software: {
+		name: 'FHIR Server',
+		version: '0.0.1'
+	},
+	implementation: {
+		description: 'FHIR Test Server (STU#)'
+	},
+	fhirVersion: '3.0.1',
+	acceptUnknown: 'extensions',
+	format: [
+		'application/fhir+json'
+	],
+	rest: [
+		resources
+	]
+});
+
+
+/**
+ * @name exports
+ * @summary Capability statement shell
+ */
+module.exports.securityStatement = securityUrls => ({
+	cors: true,
+	service: [{
+		coding: [{
+				system: 'http://hl7.org/fhir/restful-security-service',
+				code: 'SMART-on-FHIR'
+		}],
+		text: 'OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)'
+	}],
+	extension: [{
+		url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
+		extension: securityUrls
+	}]
+});

--- a/src/server/stu3/metadata/capability.js
+++ b/src/server/stu3/metadata/capability.js
@@ -16,7 +16,7 @@ module.exports.makeStatement = resources => ({
 		version: '0.0.1'
 	},
 	implementation: {
-		description: 'FHIR Test Server (STU#)'
+		description: 'FHIR Test Server (STU3)'
 	},
 	fhirVersion: '3.0.1',
 	acceptUnknown: 'extensions',

--- a/src/server/stu3/metadata/controllers/metadata.controller.js
+++ b/src/server/stu3/metadata/controllers/metadata.controller.js
@@ -1,0 +1,15 @@
+const errors = require('../../../utils/error.utils');
+const service = require('../services/metadata.service');
+
+/**
+ * @name exports
+ * @summary Metadata controller
+ */
+module.exports.getCapabilityStatement = (profiles, logger, security) => {
+
+  return (req, res, next) => {
+		return service.generateCapabilityStatement(req, profiles, logger, security)
+			.then((statement) => res.status(200).json(statement))
+			.catch((err) => next(errors.internal(err.message)));
+	};
+};

--- a/src/server/stu3/metadata/metadata.config.js
+++ b/src/server/stu3/metadata/metadata.config.js
@@ -1,0 +1,23 @@
+const controller = require('./controllers/metadata.controller');
+
+
+let routes = [
+	{
+		type: 'get',
+		path: '/stu3/metadata',
+		corsOptions: {
+			methods: ['GET']
+		},
+		args: [],
+		scopes: [],
+		controller: controller.getCapabilityStatement
+	}
+];
+
+/**
+ * @name exports
+ * @summary Metadata config
+ */
+module.exports = {
+	routes
+};

--- a/src/server/stu3/metadata/routes/metadata.routes.js
+++ b/src/server/stu3/metadata/routes/metadata.routes.js
@@ -1,0 +1,22 @@
+const cors = require('cors');
+const { sanitizeMiddleware } = require('../../../utils/sanitize.utils');
+const { routes } = require('../metadata.config');
+
+/**
+ * @name exports
+ * @summary Metadata routes
+ */
+module.exports = (app, config, logger) => {
+	routes.forEach((route) => {
+		// Enable options
+		app.options(route.path, cors(route.corsOptions));
+		// Enable route
+		app[route.type](
+			route.path,
+			cors(route.corsOptions),
+			sanitizeMiddleware(route.args),
+			route.controller(config, logger)
+		);
+	});
+
+};

--- a/src/server/stu3/metadata/services/metadata.service.js
+++ b/src/server/stu3/metadata/services/metadata.service.js
@@ -3,7 +3,7 @@ const glob = require('glob');
 const { VERSIONS } = require('../../../../constants');
 const { makeStatement, securityStatement } = require('../capability');
 
-// Glob for discovering all dstu2 conformance statements
+// Glob for discovering all stu3 conformance statements
 const files = path.resolve(__dirname, '../../*/conformance.js');
 
 // Load all the conformance documents ahead of time

--- a/src/server/stu3/metadata/services/metadata.service.js
+++ b/src/server/stu3/metadata/services/metadata.service.js
@@ -47,12 +47,12 @@ let generateCapabilityStatement = (req, config, logger) => new Promise((resolve,
 
 	// Map all the active resources
 	let active_resources = RESOURCES
-		.map(mapResources(profiles.dstu2))
+		.map(mapResources(profiles.stu3))
 		.filter(filterResources);
 
 	// Create a context I can pass some data through
 	let context = {
-		version: VERSIONS.DSTU2
+		version: VERSIONS.STU3
 	};
 
 	// Iterate over the active_resources and execute getCount for each one.
@@ -62,7 +62,7 @@ let generateCapabilityStatement = (req, config, logger) => new Promise((resolve,
 		.then((results) => {
 
 			// Our server statment
-			const server = {mode: 'server'};
+			const server = { mode: 'server' };
 			// Generate the resources conformance statement and add these to the main Capability Statement
 			server.resource = active_resources.map((resource, i) => resource.makeResource(results[i]));
 


### PR DESCRIPTION
This PR adds the necessary boilerplate for generating a capability statement for STU3. Currently resources are returned as an empty array because they are only pulled in when they are available and have defined their own conformance. So as we add resources, we need to pull in their information from a `conformance.js` file in their own directory.