### PR TITLE
Fixed issue with querying a patient that is out of context

### DIFF
--- a/src/server/dstu2/patient/controllers/patient.controller.js
+++ b/src/server/dstu2/patient/controllers/patient.controller.js
@@ -72,11 +72,11 @@ module.exports.getPatientById = (profile, logger) => {
 		// is only accessing resources with his id, he is not allowed to access others
 		if (
 			req.patient
-			&& req.body
-			&& req.body.id
-			&& req.patient !== req.body.id
+			&& req.params
+			&& req.params.id
+			&& req.patient !== req.params.id
 		) {
-			return next(errors.unauthorized(`You are not allowed to access patient ${req.body.id}.`));
+			return next(errors.unauthorized(`You are not allowed to access patient ${req.params.id}.`));
 		}
 
 		return service.getPatientById(req, logger, context)


### PR DESCRIPTION
This was an issue discovered during the ONC FHIR challenge competition during stage 2. The user was able to ask for a patient's records other than the one their token allowed them to access due to an invalid check.  For example, if the patient had the following context in their jwt token.

```javascript
context: {
  patient: "1"
},
```

and they requested `<server>/dstu2/patient/2`. They could retrieve patient records for the patient with ID 2 when the intended behavior is a 401 Unauthorized with the following message `You are not allowed to access patient 2.`

This PR fixes that issue with updating the check to check the correct url params.