### PR TITLE
Add sanitize to auth routes

### DIFF
--- a/src/server/oauth/oauth.config.js
+++ b/src/server/oauth/oauth.config.js
@@ -28,17 +28,39 @@ let routes = [
 			name: 'aud',
 			type: 'string',
 			required: true
+		},
+		{
+			name: 'launch',
+			type: 'string'
 		}],
 		scopes: [{
 			name: 'code',
 			type: 'string'
-		}],
+		},
+	],
 		controller: controller.authorize
 	},
 	{
 		type: 'post',
 		path: '/token',
-		args: [],
+		args: [{
+			name: 'grant_type',
+			type: 'string',
+			required: true
+		},
+		{
+			name: 'code',
+			type: 'string',
+			required: true
+		},
+		{
+			name: 'secret',
+			type: 'string'
+		},
+		{
+			name: 'refresh_token',
+			type: 'string'
+		}],
 		scopes: [],
 		controller: controller.token
 	}

--- a/src/server/oauth/routes/oauth.routes.js
+++ b/src/server/oauth/routes/oauth.routes.js
@@ -1,5 +1,7 @@
 const cors = require('cors');
 const { routes } = require('../oauth.config');
+const { sanitizeMiddleware } = require('../../utils/sanitize.utils');
+
 
 /**
  * @name exports
@@ -25,6 +27,7 @@ module.exports = (app, config, logger) => {
 			app[route.type](
 				route.path,
 				cors(corsOptions),
+				sanitizeMiddleware(route.args),
 				route.controller(oauth, config, logger)
 			);
 		});


### PR DESCRIPTION
Leveraging the sanitization middleware for OAUTH endpoints that is used on resource endpoints.  It sanitizes both GET and POST requests.

**BEFORE**:

request 1:
`http://localhost:3000/authorize?client_id[$gt]=${prefix}&redirect_uri=http://localhost:3000/&response_type=code&state=43220320&scope=launch patient/*.read openid&aud=http://localhost:3000`

request 1.query:
`{"client_id":{"$gt":"${prefix}"},"redirect_uri":"http://localhost:3000/","response_type":"code","state":"43220320","scope":"launch patient/*.read openid","aud":"http://localhost:3000"}`


request2:
`http://localhost:3000/authorize?client_id=<html>client_id</html>&redirect_uri=<html>redirect_uri</html>&response_type=<html>response_type</html>&state=<html>state</html>&scope=<html>scope</html>&aud=<html>aud</html>`

request2.query
`{"client_id":"<html>client_id</html>","redirect_uri":"<html>redirect_uri</html>","response_type":"<html>response_type</html>","state":"<html>state</html>","scope":"<html>scope</html>","aud":"<html>aud</html>"}`



**AFTER**:

request 1:
`http://localhost:3000/authorize?client_id[$gt]=${prefix}&redirect_uri=http://localhost:3000/&response_type=code&state=43220320&scope=launch patient/*.read openid&aud=http://localhost:3000
`

request 1.query:  client_id is now the string literal "[object Object]" and not an actual object
`{"client_id":"[object Object]","redirect_uri":"http://localhost:3000/","response_type":"code","state":"43220320","scope":"launch patient/*.read openid","aud":"http://localhost:3000"}`


request2:
`http://localhost:3000/authorize?client_id=<html>client_id</html>&redirect_uri=<html>redirect_uri</html>&response_type=<html>response_type</html>&state=<html>state</html>&scope=<html>scope</html>&aud=<html>aud</html>`

request2.query
`{"client_id":"client_id","redirect_uri":"redirect_uri","response_type":"response_type","state":"state","scope":"scope","aud":"aud"}`

