### PR TITLE
Observation Routing

### DIFF
--- a/src/server/profiles/observationresults/observationresults.config.js
+++ b/src/server/profiles/observationresults/observationresults.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const {route_args, common_args} = require('../common.arguments');
 const {CONFIG_KEYS, VERSIONS} = require('../../../constants');
 const observationresults_args = require('./observationresults.arguments');
@@ -148,5 +149,5 @@ module.exports = {
 	routeOptions: {
 		profileKey: CONFIG_KEYS.OBSERVATIONRESULTS
 	},
-	routes
+	routes: []
 };

--- a/src/server/profiles/observationsmokingstatus/observationsmokingstatus.config.js
+++ b/src/server/profiles/observationsmokingstatus/observationsmokingstatus.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const {route_args, common_args} = require('../common.arguments');
 const {CONFIG_KEYS, VERSIONS} = require('../../../constants');
 const observationsmokingstatus_args = require('./observationsmokingstatus.arguments');
@@ -148,5 +149,5 @@ module.exports = {
 	routeOptions: {
 		profileKey: CONFIG_KEYS.OBSERVATIONSMOKINGSTATUS
 	},
-	routes
+	routes: []
 };

--- a/src/server/utils/error.utils.test.js
+++ b/src/server/utils/error.utils.test.js
@@ -1,0 +1,135 @@
+const {
+	invalidParameter,
+	unauthorized,
+	insufficientScope,
+	notFound,
+	deleted,
+	internal,
+	isServerError
+} = require('./error.utils');
+
+const {
+	ISSUE,
+	VERSIONS
+} = require('../../constants');
+
+describe('Error Utils Tests', () => {
+
+	test('should return correct OperationOutcome for an invalidParameter error', () => {
+		let error = invalidParameter('Age is invalid.', VERSIONS.STU3);
+		let issue = error.issue[0];
+
+		expect(error.statusCode).toEqual(400);
+		expect(error.issue).toHaveLength(1);
+
+		expect(issue.code).toBe(ISSUE.CODE.INVALID);
+		expect(issue.severity).toBe(ISSUE.SEVERITY.ERROR);
+		expect(issue.diagnostics).toBe('Age is invalid.');
+	});
+
+	test('should return correct OperationOutcome for an unauthorized error', () => {
+		let errorWithMessage = unauthorized('You shall not pass.', VERSIONS.STU3);
+		let errorWithoutMessage = unauthorized('', VERSIONS.STU3);
+
+		expect(errorWithMessage.statusCode).toEqual(401);
+		expect(errorWithMessage.issue).toHaveLength(1);
+
+		let issueWithMessage = errorWithMessage.issue[0];
+		let issueWithoutMessage = errorWithoutMessage.issue[0];
+
+		// Check the code and severity on one
+		expect(issueWithMessage.code).toBe(ISSUE.CODE.FORBIDDEN);
+		expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+
+		// Check the message for both
+		expect(issueWithMessage.diagnostics).toBe('You shall not pass.');
+		expect(issueWithoutMessage.diagnostics).toBe('401: Unauthorized request');
+	});
+
+	test('should return correct OperationOutcome for an insufficientScope error', () => {
+		let errorWithMessage = insufficientScope('Not enough scope for this action.', VERSIONS.STU3);
+		let errorWithoutMessage = insufficientScope('', VERSIONS.STU3);
+
+		expect(errorWithMessage.statusCode).toEqual(403);
+		expect(errorWithMessage.issue).toHaveLength(1);
+
+		let issueWithMessage = errorWithMessage.issue[0];
+		let issueWithoutMessage = errorWithoutMessage.issue[0];
+
+		// Check the code and severity on one
+		expect(issueWithMessage.code).toBe(ISSUE.CODE.FORBIDDEN);
+		expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+
+		// Check the message for both
+		expect(issueWithMessage.diagnostics).toBe('Not enough scope for this action.');
+		expect(issueWithoutMessage.diagnostics).toBe('403: Insufficient scope');
+	});
+
+	test('should return correct OperationOutcome for an notFound error', () => {
+		let errorWithMessage = notFound('Somthing not found.', VERSIONS.STU3);
+		let errorWithoutMessage = notFound('', VERSIONS.STU3);
+
+		expect(errorWithMessage.statusCode).toEqual(404);
+		expect(errorWithMessage.issue).toHaveLength(1);
+
+		let issueWithMessage = errorWithMessage.issue[0];
+		let issueWithoutMessage = errorWithoutMessage.issue[0];
+
+		// Check the code and severity on one
+		expect(issueWithMessage.code).toBe(ISSUE.CODE.NOT_FOUND);
+		expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+
+		// Check the message for both
+		expect(issueWithMessage.diagnostics).toBe('Somthing not found.');
+		expect(issueWithoutMessage.diagnostics).toBe('404: Not found');
+	});
+
+	test('should return correct OperationOutcome for an deleted error', () => {
+		let errorWithMessage = deleted('This resource has been deleted.', VERSIONS.STU3);
+		let errorWithoutMessage = deleted('', VERSIONS.STU3);
+
+		expect(errorWithMessage.statusCode).toEqual(410);
+		expect(errorWithMessage.issue).toHaveLength(1);
+
+		let issueWithMessage = errorWithMessage.issue[0];
+		let issueWithoutMessage = errorWithoutMessage.issue[0];
+
+		// Check the code and severity on one
+		expect(issueWithMessage.code).toBe(ISSUE.CODE.NOT_FOUND);
+		expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+
+		// Check the message for both
+		expect(issueWithMessage.diagnostics).toBe('This resource has been deleted.');
+		expect(issueWithoutMessage.diagnostics).toBe('410: Resource deleted');
+	});
+
+	test('should return correct OperationOutcome for an internal error', () => {
+		let errorWithMessage = internal('Internal Server Error.', VERSIONS.STU3);
+		let errorWithoutMessage = internal('', VERSIONS.STU3);
+
+		expect(errorWithMessage.statusCode).toEqual(500);
+		expect(errorWithMessage.issue).toHaveLength(1);
+
+		let issueWithMessage = errorWithMessage.issue[0];
+		let issueWithoutMessage = errorWithoutMessage.issue[0];
+
+		// Check the code and severity on one
+		expect(issueWithMessage.code).toBe(ISSUE.CODE.EXCEPTION);
+		expect(issueWithoutMessage.severity).toBe(ISSUE.SEVERITY.ERROR);
+
+		// Check the message for both
+		expect(issueWithMessage.diagnostics).toBe('Internal Server Error.');
+		expect(issueWithoutMessage.diagnostics).toBe('500: Internal server error');
+	});
+
+	test('should correctly determine if an error is an OperationOutcome', () => {
+		let normalError = new Error('FooBar');
+		let operationError = invalidParameter('', VERSIONS.STU3);
+		let operationErrorWithoutVersion = invalidParameter('');
+
+		expect(isServerError(normalError, VERSIONS.STU3)).toBeFalsy();
+		expect(isServerError(operationError, VERSIONS.STU3)).toBeTruthy();
+		expect(isServerError(operationErrorWithoutVersion, VERSIONS.STU3)).toBeTruthy();
+	});
+
+});


### PR DESCRIPTION
This PR addresses the issues with Observation, Observation Results, and Observation Smoking Status routing. Currently each one has it's own separate routes which is not correct according to the specs, they are each discovered via the Observation routes. So this PR has set the routes for SmokingStatus and Results to an empty array so they won't have routes. I'd rather do this for now then delete the code as this may change in a future version and I don't want to make @imdrt redo the work he already did. 

Inside the observation callback, it will check the resulting `resourceType` and get the correct resource constructor to use before casting the resources and sending them back.

Here are the specs for these resources:
- [Results](http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-observationresults.html)
- [SmokingStatus](http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-smokingstatus.html)


#### Commits 
- Fixed routing for observations
- Added some error tests