### PR TITLE
Added defaults and ability to opt in to interactions per service

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -34,74 +34,74 @@ const CONFIG = {
 		}
 	],
 	profiles: {
-		allergyintolerance: {
-			service: './src/server/profiles/allergyintolerance/allergyintolerance.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		careplan: {
-			service: './src/server/profiles/careplan/careplan.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		careteam: {
-			service: './src/server/profiles/careteam/careteam.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		condition: {
-			service: './src/server/profiles/condition/condition.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		device: {
-			service: './src/server/profiles/device/device.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		diagnosticreport: {
-			service: './src/server/profiles/diagnosticreport/diagnosticreport.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		goal: {
-			service: './src/server/profiles/goal/goal.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		immunization: {
-			service: './src/server/profiles/immunization/immunization.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		location: {
-			service: './src/server/profiles/location/location.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		medication: {
-			service: './src/server/profiles/medication/medication.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		medicationrequest: {
-			service: './src/server/profiles/medicationrequest/medicationrequest.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		medicationstatement: {
-			service: './src/server/profiles/medicationstatement/medicationstatement.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		observation: {
-			service: './src/server/profiles/observation/observation.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		organization: {
-			service: './src/server/profiles/organization/organization.service.js',
-			versions: [VERSIONS.STU3]
-		},
+		// allergyintolerance: {
+		// 	service: './src/server/profiles/allergyintolerance/allergyintolerance.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// careplan: {
+		// 	service: './src/server/profiles/careplan/careplan.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// careteam: {
+		// 	service: './src/server/profiles/careteam/careteam.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// condition: {
+		// 	service: './src/server/profiles/condition/condition.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// device: {
+		// 	service: './src/server/profiles/device/device.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// diagnosticreport: {
+		// 	service: './src/server/profiles/diagnosticreport/diagnosticreport.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// goal: {
+		// 	service: './src/server/profiles/goal/goal.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// immunization: {
+		// 	service: './src/server/profiles/immunization/immunization.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// location: {
+		// 	service: './src/server/profiles/location/location.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// medication: {
+		// 	service: './src/server/profiles/medication/medication.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// medicationrequest: {
+		// 	service: './src/server/profiles/medicationrequest/medicationrequest.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// medicationstatement: {
+		// 	service: './src/server/profiles/medicationstatement/medicationstatement.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// observation: {
+		// 	service: './src/server/profiles/observation/observation.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// organization: {
+		// 	service: './src/server/profiles/organization/organization.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
 		patient: {
 			service: './src/server/profiles/patient/patient.service.js',
 			versions: [VERSIONS.STU3]
 		},
-		practitioner: {
-			service: './src/server/profiles/practitioner/practitioner.service.js',
-			versions: [VERSIONS.STU3]
-		},
-		procedure: {
-			service: './src/server/profiles/procedure/procedure.service.js',
-			versions: [VERSIONS.STU3]
-		}
+		// practitioner: {
+		// 	service: './src/server/profiles/practitioner/practitioner.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// },
+		// procedure: {
+		// 	service: './src/server/profiles/procedure/procedure.service.js',
+		// 	versions: [VERSIONS.STU3]
+		// }
 	}
 };
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -34,74 +34,74 @@ const CONFIG = {
 		}
 	],
 	profiles: {
-		// allergyintolerance: {
-		// 	service: './src/server/profiles/allergyintolerance/allergyintolerance.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// careplan: {
-		// 	service: './src/server/profiles/careplan/careplan.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// careteam: {
-		// 	service: './src/server/profiles/careteam/careteam.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// condition: {
-		// 	service: './src/server/profiles/condition/condition.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// device: {
-		// 	service: './src/server/profiles/device/device.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// diagnosticreport: {
-		// 	service: './src/server/profiles/diagnosticreport/diagnosticreport.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// goal: {
-		// 	service: './src/server/profiles/goal/goal.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// immunization: {
-		// 	service: './src/server/profiles/immunization/immunization.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// location: {
-		// 	service: './src/server/profiles/location/location.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// medication: {
-		// 	service: './src/server/profiles/medication/medication.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// medicationrequest: {
-		// 	service: './src/server/profiles/medicationrequest/medicationrequest.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// medicationstatement: {
-		// 	service: './src/server/profiles/medicationstatement/medicationstatement.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// observation: {
-		// 	service: './src/server/profiles/observation/observation.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// organization: {
-		// 	service: './src/server/profiles/organization/organization.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
+		allergyintolerance: {
+			service: './src/server/profiles/allergyintolerance/allergyintolerance.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		careplan: {
+			service: './src/server/profiles/careplan/careplan.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		careteam: {
+			service: './src/server/profiles/careteam/careteam.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		condition: {
+			service: './src/server/profiles/condition/condition.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		device: {
+			service: './src/server/profiles/device/device.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		diagnosticreport: {
+			service: './src/server/profiles/diagnosticreport/diagnosticreport.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		goal: {
+			service: './src/server/profiles/goal/goal.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		immunization: {
+			service: './src/server/profiles/immunization/immunization.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		location: {
+			service: './src/server/profiles/location/location.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		medication: {
+			service: './src/server/profiles/medication/medication.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		medicationrequest: {
+			service: './src/server/profiles/medicationrequest/medicationrequest.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		medicationstatement: {
+			service: './src/server/profiles/medicationstatement/medicationstatement.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		observation: {
+			service: './src/server/profiles/observation/observation.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		organization: {
+			service: './src/server/profiles/organization/organization.service.js',
+			versions: [VERSIONS.STU3]
+		},
 		patient: {
 			service: './src/server/profiles/patient/patient.service.js',
 			versions: [VERSIONS.STU3]
 		},
-		// practitioner: {
-		// 	service: './src/server/profiles/practitioner/practitioner.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// },
-		// procedure: {
-		// 	service: './src/server/profiles/procedure/procedure.service.js',
-		// 	versions: [VERSIONS.STU3]
-		// }
+		practitioner: {
+			service: './src/server/profiles/practitioner/practitioner.service.js',
+			versions: [VERSIONS.STU3]
+		},
+		procedure: {
+			service: './src/server/profiles/procedure/procedure.service.js',
+			versions: [VERSIONS.STU3]
+		}
 	}
 };
 

--- a/src/server/profiles/allergyintolerance/allergyintolerance.config.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/allergyintolerance',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -45,7 +44,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/allergyintolerance/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -79,7 +77,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/allergyintolerance/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -90,7 +87,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/allergyintolerance',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -102,7 +98,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/allergyintolerance/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -114,7 +109,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/allergyintolerance/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getAllergyIntolerance = ({ profile, logger, config, app }) => {
+module.exports.getAllergyIntolerance = function getAllergyIntolerance ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -26,7 +26,7 @@ module.exports.getAllergyIntolerance = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getAllergyIntoleranceById = ({ profile, logger, app }) => {
+module.exports.getAllergyIntoleranceById = function getAllergyIntoleranceById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -48,7 +48,7 @@ module.exports.getAllergyIntoleranceById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a allergy_intolerance
 */
-module.exports.createAllergyIntolerance = ({ profile, logger, app }) => {
+module.exports.createAllergyIntolerance = function createAllergyIntolerance ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -80,7 +80,7 @@ module.exports.createAllergyIntolerance = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a allergy_intolerance. If the allergy_intolerance does not exist, it should be updated
 */
-module.exports.updateAllergyIntolerance = ({ profile, logger, app }) => {
+module.exports.updateAllergyIntolerance = function updateAllergyIntolerance ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -112,7 +112,7 @@ module.exports.updateAllergyIntolerance = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an allergy_intolerance.
 */
-module.exports.deleteAllergyIntolerance = ({ profile, logger, app }) => {
+module.exports.deleteAllergyIntolerance = function deleteAllergyIntolerance ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/allergyintolerance/conformance.js
+++ b/src/server/profiles/allergyintolerance/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-allergyintolerance.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/careplan/careplan.config.js
+++ b/src/server/profiles/careplan/careplan.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/careplan',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -49,7 +48,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/careplan/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -87,7 +85,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/careplan/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -98,7 +95,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/careplan',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -110,7 +106,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/careplan/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -122,7 +117,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/careplan/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/careplan/careplan.controller.js
+++ b/src/server/profiles/careplan/careplan.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getCarePlan = ({ profile, logger, config, app }) => {
+module.exports.getCarePlan = function getCarePlan ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getCarePlan = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getCarePlanById = ({ profile, logger, app }) => {
+module.exports.getCarePlanById = function getCarePlanById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getCarePlanById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a care_plan
 */
-module.exports.createCarePlan = ({ profile, logger, app }) => {
+module.exports.createCarePlan = function createCarePlan ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createCarePlan = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a care_plan. If the care_plan does not exist, it should be updated
 */
-module.exports.updateCarePlan = ({ profile, logger, app }) => {
+module.exports.updateCarePlan = function updateCarePlan ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateCarePlan = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an care plan resource.
 */
-module.exports.deleteCarePlan = ({ profile, logger, app }) => {
+module.exports.deleteCarePlan = function deleteCarePlan ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/careplan/conformance.js
+++ b/src/server/profiles/careplan/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/capstmnts.html#careplan'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/careteam/careteam.config.js
+++ b/src/server/profiles/careteam/careteam.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/careteam',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -38,7 +37,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/careteam/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -65,7 +63,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/careteam/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -76,7 +73,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/careteam',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -88,7 +84,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/careteam/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -100,7 +95,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/careteam/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/careteam/careteam.controller.js
+++ b/src/server/profiles/careteam/careteam.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getCareTeam = ({ profile, logger, config, app }) => {
+module.exports.getCareTeam = function getCareTeam ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getCareTeam = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getCareTeamById = ({ profile, logger, app }) => {
+module.exports.getCareTeamById = function getCareTeamById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getCareTeamById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a care_team
 */
-module.exports.createCareTeam = ({ profile, logger, app }) => {
+module.exports.createCareTeam = function createCareTeam ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createCareTeam = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a care_team. If the care_team does not exist, it should be updated
 */
-module.exports.updateCareTeam = ({ profile, logger, app }) => {
+module.exports.updateCareTeam = function updateCareTeam ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateCareTeam = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an care team resource.
 */
-module.exports.deleteCareTeam = ({ profile, logger, app }) => {
+module.exports.deleteCareTeam = function deleteCareTeam ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/careteam/conformance.js
+++ b/src/server/profiles/careteam/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-careteam.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/condition/condition.config.js
+++ b/src/server/profiles/condition/condition.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/condition',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -52,7 +51,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/condition/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -93,7 +91,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/condition/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -104,7 +101,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/condition',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -116,7 +112,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/condition/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -128,7 +123,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/condition/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/condition/condition.controller.js
+++ b/src/server/profiles/condition/condition.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getCondition = ({ profile, logger, config, app }) => {
+module.exports.getCondition = function getCondition ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getCondition = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getConditionById = ({ profile, logger, app }) => {
+module.exports.getConditionById = function getConditionById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getConditionById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a condition
 */
-module.exports.createCondition = ({ profile, logger, app }) => {
+module.exports.createCondition = function createCondition ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createCondition = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a condition. If the condition does not exist, it should be updated
 */
-module.exports.updateCondition = ({ profile, logger, app }) => {
+module.exports.updateCondition = function updateCondition ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateCondition = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an condition resource.
 */
-module.exports.deleteCondition = ({ profile, logger, app }) => {
+module.exports.deleteCondition = function deleteCondition ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/condition/conformance.js
+++ b/src/server/profiles/condition/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-condition.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/device/conformance.js
+++ b/src/server/profiles/device/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-device.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/device/device.config.js
+++ b/src/server/profiles/device/device.config.js
@@ -12,7 +12,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/device',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -42,7 +41,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/device/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -72,7 +70,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/device/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -83,7 +80,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/device',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -95,7 +91,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/device/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -107,7 +102,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/device/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/device/device.controller.js
+++ b/src/server/profiles/device/device.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getDevice = ({ profile, logger, config, app }) => {
+module.exports.getDevice = function getDevice ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getDevice = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getDeviceById = ({ profile, logger, app }) => {
+module.exports.getDeviceById = function getDeviceById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getDeviceById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a device
 */
-module.exports.createDevice = ({ profile, logger, app }) => {
+module.exports.createDevice = function createDevice ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createDevice = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a device. If the device does not exist, it should be updated
 */
-module.exports.updateDevice = ({ profile, logger, app }) => {
+module.exports.updateDevice = function updateDevice ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateDevice = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a device resource.
 */
-module.exports.deleteDevice = ({ profile, logger, app }) => {
+module.exports.deleteDevice = function deleteDevice ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/diagnosticreport/conformance.js
+++ b/src/server/profiles/diagnosticreport/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-diagnosticreport.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/diagnosticreport/diagnosticreport.config.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.config.js
@@ -13,7 +13,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/diagnosticreport',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -47,7 +46,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/diagnosticreport/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -81,7 +79,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/diagnosticreport/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -92,7 +89,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/diagnosticreport',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -104,7 +100,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/diagnosticreport/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -116,7 +111,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/diagnosticreport/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getDiagnosticReport = ({ profile, logger, config, app }) => {
+module.exports.getDiagnosticReport = function getDiagnosticReport ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getDiagnosticReport = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getDiagnosticReportById = ({ profile, logger, app }) => {
+module.exports.getDiagnosticReportById = function getDiagnosticReportById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getDiagnosticReportById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a diagnostic_report
 */
-module.exports.createDiagnosticReport = ({ profile, logger, app }) => {
+module.exports.createDiagnosticReport = function createDiagnosticReport ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createDiagnosticReport = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a diagnostic_report. If the diagnostic_report does not exist, it should be updated
 */
-module.exports.updateDiagnosticReport = ({ profile, logger, app }) => {
+module.exports.updateDiagnosticReport = function updateDiagnosticReport ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateDiagnosticReport = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an DiagnosticReport resource.
 */
-module.exports.deleteDiagnosticReport = ({ profile, logger, app }) => {
+module.exports.deleteDiagnosticReport = function deleteDiagnosticReport ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/goal/conformance.js
+++ b/src/server/profiles/goal/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-goal.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/goal/goal.config.js
+++ b/src/server/profiles/goal/goal.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/goal',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -36,7 +35,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/goal/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -61,7 +59,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/goal/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -72,7 +69,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/goal',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -84,7 +80,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/goal/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -96,7 +91,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/goal/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/goal/goal.controller.js
+++ b/src/server/profiles/goal/goal.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getGoal = ({ profile, logger, config, app }) => {
+module.exports.getGoal = function getGoal ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getGoal = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getGoalById = ({ profile, logger, app }) => {
+module.exports.getGoalById = function getGoalById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getGoalById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a goal
 */
-module.exports.createGoal = ({ profile, logger, app }) => {
+module.exports.createGoal = function createGoal ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createGoal = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a goal. If the goal does not exist, it should be updated
 */
-module.exports.updateGoal = ({ profile, logger, app }) => {
+module.exports.updateGoal = function updateGoal ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateGoal = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a goal resource.
 */
-module.exports.deleteGoal = ({ profile, logger, app }) => {
+module.exports.deleteGoal = function deleteGoal ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/immunization/conformance.js
+++ b/src/server/profiles/immunization/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-immunization.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/immunization/immunization.config.js
+++ b/src/server/profiles/immunization/immunization.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/immunization',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -44,7 +43,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/immunization/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -77,7 +75,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/immunization/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -88,7 +85,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/immunization',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -100,7 +96,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/immunization/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -112,7 +107,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/immunization/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/immunization/immunization.controller.js
+++ b/src/server/profiles/immunization/immunization.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getImmunization = ({ profile, logger, config, app }) => {
+module.exports.getImmunization = function getImmunization ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getImmunization = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getImmunizationById = ({ profile, logger, app }) => {
+module.exports.getImmunizationById = function getImmunizationById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getImmunizationById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a immunization
 */
-module.exports.createImmunization = ({ profile, logger, app }) => {
+module.exports.createImmunization = function createImmunization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createImmunization = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a immunization. If the immunization does not exist, it should be updated
 */
-module.exports.updateImmunization = ({ profile, logger, app }) => {
+module.exports.updateImmunization = function updateImmunization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateImmunization = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an immunization resource.
 */
-module.exports.deleteImmunization = ({ profile, logger, app }) => {
+module.exports.deleteImmunization = function deleteImmunization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/location/conformance.js
+++ b/src/server/profiles/location/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-location.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/location/location.config.js
+++ b/src/server/profiles/location/location.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/location',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -45,7 +44,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/location/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -79,7 +77,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/location/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -90,7 +87,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/location',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -102,7 +98,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/location/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -114,7 +109,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/location/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/location/location.controller.js
+++ b/src/server/profiles/location/location.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/error.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getLocation = ({ profile, logger, config, app }) => {
+module.exports.getLocation = function getLocation ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getLocation = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getLocationById = ({ profile, logger, app }) => {
+module.exports.getLocationById = function getLocationById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getLocationById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a location
 */
-module.exports.createLocation = ({ profile, logger, app }) => {
+module.exports.createLocation = function createLocation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createLocation = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a location. If the location does not exist, it should be updated
 */
-module.exports.updateLocation = ({ profile, logger, app }) => {
+module.exports.updateLocation = function updateLocation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateLocation = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a location resource.
 */
-module.exports.deleteLocation = ({ profile, logger, app }) => {
+module.exports.deleteLocation = function deleteLocation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/medication/conformance.js
+++ b/src/server/profiles/medication/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-medication.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/medication/medication.config.js
+++ b/src/server/profiles/medication/medication.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medication',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -39,7 +38,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medication/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -67,7 +65,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medication/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -78,7 +75,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medication',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -90,7 +86,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/medication/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -102,7 +97,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/medication/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/medication/medication.controller.js
+++ b/src/server/profiles/medication/medication.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getMedication = ({ profile, logger, config, app }) => {
+module.exports.getMedication = function getMedication ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getMedication = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getMedicationById = ({ profile, logger, app }) => {
+module.exports.getMedicationById = function getMedicationById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getMedicationById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a medication
 */
-module.exports.createMedication = ({ profile, logger, app }) => {
+module.exports.createMedication = function createMedication ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createMedication = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a medication. If the medication does not exist, it should be updated
 */
-module.exports.updateMedication = ({ profile, logger, app }) => {
+module.exports.updateMedication = function updateMedication ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateMedication = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a medication resource.
 */
-module.exports.deleteMedication = ({ profile, logger, app }) => {
+module.exports.deleteMedication = function deleteMedication ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/medicationrequest/conformance.js
+++ b/src/server/profiles/medicationrequest/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-medicationrequest.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/medicationrequest/medicationrequest.config.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medicationrequest',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -43,7 +42,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medicationrequest/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -75,7 +73,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medicationrequest/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -86,7 +83,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medicationrequest',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -98,7 +94,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/medicationrequest/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -110,7 +105,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/medicationrequest/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/medicationrequest/medicationrequest.controller.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getMedicationRequest = ({ profile, logger, config, app }) => {
+module.exports.getMedicationRequest = function getMedicationRequest ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getMedicationRequest = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getMedicationRequestById = ({ profile, logger, app }) => {
+module.exports.getMedicationRequestById = function getMedicationRequestById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getMedicationRequestById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a medication_request
 */
-module.exports.createMedicationRequest = ({ profile, logger, app }) => {
+module.exports.createMedicationRequest = function createMedicationRequest ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createMedicationRequest = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a medication_request. If the medication_request does not exist, it should be updated
 */
-module.exports.updateMedicationRequest = ({ profile, logger, app }) => {
+module.exports.updateMedicationRequest = function updateMedicationRequest ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateMedicationRequest = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a medication request resource.
 */
-module.exports.deleteMedicationRequest = ({ profile, logger, app }) => {
+module.exports.deleteMedicationRequest = function deleteMedicationRequest ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/medicationstatement/conformance.js
+++ b/src/server/profiles/medicationstatement/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://www.hl7.org/fhir/us/core/StructureDefinition-us-core-medicationstatement.html'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/medicationstatement/medicationstatement.config.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medicationstatement',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -40,7 +39,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medicationstatement/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -69,7 +67,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/medicationstatement/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -80,7 +77,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/medicationstatement',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -92,7 +88,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/medicationstatement/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -104,7 +99,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/medicationstatement/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/medicationstatement/medicationstatement.controller.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getMedicationStatement = ({ profile, logger, config, app }) => {
+module.exports.getMedicationStatement = function getMedicationStatement ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getMedicationStatement = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getMedicationStatementById = ({ profile, logger, app }) => {
+module.exports.getMedicationStatementById = function getMedicationStatementById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getMedicationStatementById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a medication_statement
 */
-module.exports.createMedicationStatement = ({ profile, logger, app }) => {
+module.exports.createMedicationStatement = function createMedicationStatement ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createMedicationStatement = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a medication_statement. If the medication_statement does not exist, it should be updated
 */
-module.exports.updateMedicationStatement = ({ profile, logger, app }) => {
+module.exports.updateMedicationStatement = function updateMedicationStatement ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateMedicationStatement = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an medication statement resource.
 */
-module.exports.deleteMedicationStatement = ({ profile, logger, app }) => {
+module.exports.deleteMedicationStatement = function deleteMedicationStatement ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/metadata/metadata.interactions.js
+++ b/src/server/profiles/metadata/metadata.interactions.js
@@ -1,0 +1,41 @@
+/**
+* Generate a list of interactions a particular profile can support
+* keep a local copy of interactions so this does not need to happen each time
+*/
+let profileInteractions = {};
+let generateInteractions = (service, resourceType) => {
+	// return from cache if it exists
+	if (profileInteractions[resourceType]) {
+		return profileInteractions[resourceType];
+	}
+
+	let interactions = [];
+
+	// Test for the existence of a service method
+	if (service[`get${resourceType}`]) {
+		interactions.push({ code: 'search' });
+	}
+
+	if (service[`get${resourceType}ById`]) {
+		interactions.push({ code: 'read' });
+	}
+
+	if (service[`create${resourceType}`]) {
+		interactions.push({ code: 'create' });
+	}
+
+	if (service[`update${resourceType}`]) {
+		interactions.push({ code: 'update' });
+	}
+
+	if (service[`delete${resourceType}`]) {
+		interactions.push({ code: 'delete' });
+	}
+
+	// Save these interactions so we don't need to do this again
+	profileInteractions[resourceType] = interactions;
+
+	return interactions;
+};
+
+module.exports = generateInteractions;

--- a/src/server/profiles/metadata/metadata.service.js
+++ b/src/server/profiles/metadata/metadata.service.js
@@ -1,3 +1,4 @@
+const generateInteractions = require('./metadata.interactions');
 const { VERSIONS } = require('../../../constants');
 const errors = require('../../utils/error.utils');
 const path = require('path');
@@ -50,46 +51,6 @@ let getStatementGenerators = (version) => {
 		case VERSIONS.STU3: return require('./capability.stu3');
 		default: return {};
 	}
-};
-
-/**
-* Generate a list of interactions a particular profile can support
-* keep a local copy of interactions so this does not need to happen each time
-*/
-let resourceInteractions = {};
-let generateInteractions = (service, resourceType) => {
-	// return from cache if it exists
-	if (resourceInteractions[resourceType]) {
-		return resourceInteractions[resourceType];
-	}
-
-	let interactions = [];
-
-	// Test for the existence of a service method
-	if (service[`get${resourceType}`]) {
-		interactions.push({ code: 'search' });
-	}
-
-	if (service[`get${resourceType}ById`]) {
-		interactions.push({ code: 'read' });
-	}
-
-	if (service[`create${resourceType}`]) {
-		interactions.push({ code: 'create' });
-	}
-
-	if (service[`update${resourceType}`]) {
-		interactions.push({ code: 'update' });
-	}
-
-	if (service[`delete${resourceType}`]) {
-		interactions.push({ code: 'delete' });
-	}
-
-	// Save these interactions so we don't need to do this again
-	resourceInteractions[resourceType] = interactions;
-
-	return interactions;
 };
 
 /**

--- a/src/server/profiles/observation/conformance.js
+++ b/src/server/profiles/observation/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://hl7.org/fhir/Profile/Observation'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/observation/observation.config.js
+++ b/src/server/profiles/observation/observation.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/observation',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -67,7 +66,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/observation/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -123,7 +121,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/observation/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -134,7 +131,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/observation',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -146,7 +142,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/observation/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -158,7 +153,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/observation/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/observation/observation.controller.js
+++ b/src/server/profiles/observation/observation.controller.js
@@ -21,7 +21,7 @@ let getResourceConstructor = (version, resourceType) => {
 	}
 };
 
-module.exports.getObservation = ({ profile, logger, config, app }) => {
+module.exports.getObservation = function getObservation ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -66,7 +66,7 @@ module.exports.getObservation = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getObservationById = ({ profile, logger, app }) => {
+module.exports.getObservationById = function getObservationById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -87,7 +87,7 @@ module.exports.getObservationById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a observation
 */
-module.exports.createObservation = ({ profile, logger, app }) => {
+module.exports.createObservation = function createObservation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -119,7 +119,7 @@ module.exports.createObservation = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a observation. If the observation does not exist, it should be updated
 */
-module.exports.updateObservation = ({ profile, logger, app }) => {
+module.exports.updateObservation = function updateObservation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -151,7 +151,7 @@ module.exports.updateObservation = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an observation resource.
 */
-module.exports.deleteObservation = ({ profile, logger, app }) => {
+module.exports.deleteObservation = function deleteObservation ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/organization/conformance.js
+++ b/src/server/profiles/organization/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://hl7.org/fhir/Profile/Organization'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/organization/organization.config.js
+++ b/src/server/profiles/organization/organization.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/organization',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -42,7 +41,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/organization/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -73,7 +71,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/organization/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -84,7 +81,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/organization',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -96,7 +92,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/organization/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -108,7 +103,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/organization/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/organization/organization.controller.js
+++ b/src/server/profiles/organization/organization.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getOrganization = ({ profile, logger, config, app }) => {
+module.exports.getOrganization = function getOrganization ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getOrganization = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getOrganizationById = ({ profile, logger, app }) => {
+module.exports.getOrganizationById = function getOrganizationById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getOrganizationById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a organization
 */
-module.exports.createOrganization = ({ profile, logger, app }) => {
+module.exports.createOrganization = function createOrganization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createOrganization = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a organization. If the organization does not exist, it should be updated
 */
-module.exports.updateOrganization = ({ profile, logger, app }) => {
+module.exports.updateOrganization = function updateOrganization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateOrganization = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting an organization resource.
 */
-module.exports.deleteOrganization = ({ profile, logger, app }) => {
+module.exports.deleteOrganization = function deleteOrganization ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/patient/conformance.js
+++ b/src/server/profiles/patient/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://hl7.org/fhir/Profile/Patient'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/patient/patient.config.js
+++ b/src/server/profiles/patient/patient.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/patient',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -53,7 +52,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/patient/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -95,7 +93,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/patient/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -106,7 +103,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/patient',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -118,7 +114,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/patient/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -130,7 +125,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/patient/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/patient/patient.controller.js
+++ b/src/server/profiles/patient/patient.controller.js
@@ -21,7 +21,7 @@ let patient_filter = function (user_id) {
 	return (patient) => !user_id || user_id === patient.id;
 };
 
-module.exports.getPatient = ({ profile, logger, config, app }) => {
+module.exports.getPatient = function getPatient ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -45,7 +45,7 @@ module.exports.getPatient = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getPatientById = ({ profile, logger, app }) => {
+module.exports.getPatientById = function getPatientById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -93,7 +93,7 @@ module.exports.getPatientById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a patient
 */
-module.exports.createPatient = ({ profile, logger, app }) => {
+module.exports.createPatient = function createPatient ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -125,7 +125,7 @@ module.exports.createPatient = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a patient. If the patient does not exist, it should be updated
 */
-module.exports.updatePatient = ({ profile, logger, app }) => {
+module.exports.updatePatient = function updatePatient ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -157,7 +157,7 @@ module.exports.updatePatient = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a patient resource.
 */
-module.exports.deletePatient = ({ profile, logger, app }) => {
+module.exports.deletePatient = function deletePatient ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/practitioner/conformance.js
+++ b/src/server/profiles/practitioner/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://hl7.org/fhir/Profile/Practitioner'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/practitioner/practitioner.config.js
+++ b/src/server/profiles/practitioner/practitioner.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/practitioner',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -81,7 +80,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/practitioner/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -92,7 +90,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/practitioner',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -104,7 +101,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/practitioner/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -116,7 +112,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/practitioner/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/practitioner/practitioner.controller.js
+++ b/src/server/profiles/practitioner/practitioner.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getPractitioner = ({ profile, logger, config, app }) => {
+module.exports.getPractitioner = function getPractitioner ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getPractitioner = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getPractitionerById = ({ profile, logger, app }) => {
+module.exports.getPractitionerById = function getPractitionerById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getPractitionerById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a practitioner
 */
-module.exports.createPractitioner = ({ profile, logger, app }) => {
+module.exports.createPractitioner = function createPractitioner ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createPractitioner = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a practitioner. If the practitioner does not exist, it should be updated
 */
-module.exports.updatePractitioner = ({ profile, logger, app }) => {
+module.exports.updatePractitioner = function updatePractitioner ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updatePractitioner = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a practitioner resource.
 */
-module.exports.deletePractitioner = ({ profile, logger, app }) => {
+module.exports.deletePractitioner = function deletePractitioner ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/profiles/procedure/conformance.js
+++ b/src/server/profiles/procedure/conformance.js
@@ -23,17 +23,6 @@ module.exports = {
 				reference: 'http://hl7.org/fhir/Profile/Procedure'
 			},
 			conditionalDelete: 'not-supported',
-			interaction: [{
-				code: 'read'
-			}, {
-				code: 'search'
-			}, {
-				code: 'update'
-			}, {
-				code: 'create'
-			}, {
-				code: 'delete'
-			}],
 			searchParam: searchParams
 		};
 	}

--- a/src/server/profiles/procedure/procedure.config.js
+++ b/src/server/profiles/procedure/procedure.config.js
@@ -11,7 +11,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/procedure',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -43,7 +42,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/procedure/_search',
-		corsOptions: {methods: ['POST']},
 		args: [
 			route_args.VERSION,
 			common_args._FORMAT,
@@ -75,7 +73,6 @@ let routes = [
 	{
 		type: 'get',
 		path: '/:version/procedure/:id',
-		corsOptions: {methods: ['GET']},
 		args: [
 			route_args.VERSION,
 			route_args.ID
@@ -86,7 +83,6 @@ let routes = [
 	{
 		type: 'post',
 		path: '/:version/procedure',
-		corsOptions: { methods: ['POST'] },
 		args: [
 			route_args.VERSION,
 			write_args.RESOURCE_ID,
@@ -98,7 +94,6 @@ let routes = [
 	{
 		type: 'put',
 		path: '/:version/procedure/:id',
-		corsOptions: { methods: ['PUT'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,
@@ -110,7 +105,6 @@ let routes = [
 	{
 		type: 'delete',
 		path: '/:version/procedure/:id',
-		corsOptions: { methods: ['DELETE'] },
 		args: [
 			route_args.ID,
 			route_args.VERSION,

--- a/src/server/profiles/procedure/procedure.controller.js
+++ b/src/server/profiles/procedure/procedure.controller.js
@@ -3,7 +3,7 @@ const { resolveFromVersion } = require('../../utils/resolve.utils');
 const responseUtils = require('../../utils/response.utils');
 const errors = require('../../utils/error.utils');
 
-module.exports.getProcedure = ({ profile, logger, config, app }) => {
+module.exports.getProcedure = function getProcedure ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -27,7 +27,7 @@ module.exports.getProcedure = ({ profile, logger, config, app }) => {
 };
 
 
-module.exports.getProcedureById = ({ profile, logger, app }) => {
+module.exports.getProcedureById = function getProcedureById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -49,7 +49,7 @@ module.exports.getProcedureById = ({ profile, logger, app }) => {
 /**
 * @description Controller for creating a procedure
 */
-module.exports.createProcedure = ({ profile, logger, app }) => {
+module.exports.createProcedure = function createProcedure ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -81,7 +81,7 @@ module.exports.createProcedure = ({ profile, logger, app }) => {
 /**
 * @description Controller for updating/creating a procedure. If the procedure does not exist, it should be updated
 */
-module.exports.updateProcedure = ({ profile, logger, app }) => {
+module.exports.updateProcedure = function updateProcedure ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
@@ -113,7 +113,7 @@ module.exports.updateProcedure = ({ profile, logger, app }) => {
 /**
 * @description Controller for deleting a procedure resource.
 */
-module.exports.deleteProcedure = ({ profile, logger, app }) => {
+module.exports.deleteProcedure = function deleteProcedure ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {

--- a/src/server/route.config.test.js
+++ b/src/server/route.config.test.js
@@ -53,12 +53,12 @@ describe('Route Config Tests', () => {
 
 	test('should have a function name for all route.controllers except for metadata', () => {
 		routeConfigs.forEach((config) => {
-      // Routes must be an array
-      let { routes } = config;
+			// Routes must be an array
+			let { routes } = config;
 			// We use these to make sure each provided service module has the necessary service
 			// to enable a route, the service must have a method that matches the controller's name
 			// if the controller does not have a name, we have no way to make that determination
-      routes.forEach(route => {
+			routes.forEach(route => {
 				// Ignore metadata
 				if (route.isMetadata) {
 					return;

--- a/src/server/route.config.test.js
+++ b/src/server/route.config.test.js
@@ -51,4 +51,21 @@ describe('Route Config Tests', () => {
     });
   });
 
+	test('should have a function name for all route.controllers except for metadata', () => {
+		routeConfigs.forEach((config) => {
+      // Routes must be an array
+      let { routes } = config;
+			// We use these to make sure each provided service module has the necessary service
+			// to enable a route, the service must have a method that matches the controller's name
+			// if the controller does not have a name, we have no way to make that determination
+      routes.forEach(route => {
+				// Ignore metadata
+				if (route.isMetadata) {
+					return;
+				}
+				expect(route.controller.name).not.toEqual('');
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
**What's here**

* Removed required corsOptions from route configs. Route setter now uses the route type (which is an http method) as the default for the methods allowed in cors
* Added ability to implement only the services you want to support in each profile. So for example, before, if you opted in to the patient profile, you had to support all patient routes and create patient services for each one. Meaning if you did not want to delete, you had no way of doing that. The route would exist but throw an error if you did not implement the method. Now, you can omit any method you like and the routes will not be available. Also the interactions in the conformance statement are generated based on that so if you omit delete, your conformance won't say you support delete.