### PR TITLE
Updated conformance code for search to search-type

### DIFF
--- a/src/server/profiles/common.arguments.js
+++ b/src/server/profiles/common.arguments.js
@@ -41,48 +41,48 @@ module.exports.common_args = {
 		name: '_content',
 		type: 'string',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_FORMAT: {
 		name: '_format',
 		type: 'string',
 		definition: 'https://www.hl7.org/fhir/http.html#mime-type',
-		documentation: ''
+		documentation: undefined
 	},
 	_ID: {
 		name: '_id',
 		type: 'token',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_LASTUPDATED: {
 		name: '_lastUpdated',
 		type: 'date',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_PROFILE: {
 		name: '_profile',
 		type: 'uri',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_QUERY: {
 		name: '_query',
 		type: 'token',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_SECURITY: {
 		name: '_security',
 		type: 'token',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	},
 	_TAG: {
 		name: '_tag',
 		type: 'token',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#resource',
-		documentation: ''
+		documentation: undefined
 	}
 };

--- a/src/server/profiles/medicationrequest/medicationrequest.arguments.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.arguments.js
@@ -73,18 +73,18 @@ module.exports = {
 		name: 'requester',
 		type: 'reference',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#medicationrequest',
-		documentation: ''
+		documentation: undefined
 	},
 	STATUS: {
 		name: 'status',
 		type: 'token',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#medicationrequest',
-		documentation: ''
+		documentation: undefined
 	},
 	SUBJECT: {
 		name: 'subject',
 		type: 'reference',
 		definition: 'https://www.hl7.org/fhir/searchparameter-registry.html#medicationrequest',
-		documentation: ''
+		documentation: undefined
 	}
 };

--- a/src/server/profiles/metadata/metadata.interactions.js
+++ b/src/server/profiles/metadata/metadata.interactions.js
@@ -13,7 +13,7 @@ let generateInteractions = (service, resourceType) => {
 
 	// Test for the existence of a service method
 	if (service[`get${resourceType}`]) {
-		interactions.push({ code: 'search' });
+		interactions.push({ code: 'search-type' });
 	}
 
 	if (service[`get${resourceType}ById`]) {


### PR DESCRIPTION
Empty conformance fails testing.  Changed to undefined so it doesn't get added to the conformance.