### PR TITLE
Renamed version to base

### DIFF
--- a/src/server/profiles.test.js
+++ b/src/server/profiles.test.js
@@ -18,7 +18,7 @@ describe('Generic Profile Tests', () => {
 	beforeAll(() => {
 		// Grab all the routes for all of our profiles
 		profileRoutes = glob
-			.sync('src/server/profiles/visionprescription/*.config.js')
+			.sync('src/server/profiles/**/*.config.js')
 			.map(filepath => require(path.resolve(filepath)))
 			.map(config => config.routes);
 
@@ -47,7 +47,6 @@ describe('Generic Profile Tests', () => {
 				// Make sure the severity is error
 				let issue = err.issue[0];
 				expect(issue.severity).toBe('error');
-				console.log(issue);
 			}
 		}
 	}, 60000);

--- a/src/server/profiles.test.js
+++ b/src/server/profiles.test.js
@@ -11,14 +11,14 @@ let profileRoutes,
 		server;
 
 // Helper function to replace express params with mock values
-let fillRoute = route => route.replace(':version', VERSIONS.STU3).replace(':id', 1);
+let fillRoute = route => route.replace(':base', VERSIONS.STU3).replace(':id', 1);
 
 describe('Generic Profile Tests', () => {
 
 	beforeAll(() => {
 		// Grab all the routes for all of our profiles
 		profileRoutes = glob
-			.sync('src/server/profiles/*/*.config.js')
+			.sync('src/server/profiles/visionprescription/*.config.js')
 			.map(filepath => require(path.resolve(filepath)))
 			.map(config => config.routes);
 
@@ -47,6 +47,7 @@ describe('Generic Profile Tests', () => {
 				// Make sure the severity is error
 				let issue = err.issue[0];
 				expect(issue.severity).toBe('error');
+				console.log(issue);
 			}
 		}
 	}, 60000);

--- a/src/server/profiles/account/account.config.js
+++ b/src/server/profiles/account/account.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/account',
+		path: '/:base/account',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/account/_search',
+		path: '/:base/account/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/account/:id',
+		path: '/:base/account/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/account',
+		path: '/:base/account',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/account/:id',
+		path: '/:base/account/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/account/:id',
+		path: '/:base/account/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/account/account.controller.js
+++ b/src/server/profiles/account/account.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Account = require(resolveFromVersion(version, 'base/Account'));
+		let Account = require(resolveFromVersion(base, 'base/Account'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Account, results, {
+				responseUtils.handleBundleReadResponse( res, base, Account, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Account = require(resolveFromVersion(version, 'base/Account'));
+		let Account = require(resolveFromVersion(base, 'base/Account'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Account, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Account, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Account = require(resolveFromVersion(version, 'base/Account'));
+		let Account = require(resolveFromVersion(base, 'base/Account'));
 		// Validate the resource type before creating it
 		if (Account.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Account.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Account.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Account.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Account = require(resolveFromVersion(version, 'base/Account'));
+		let Account = require(resolveFromVersion(base, 'base/Account'));
 		// Validate the resource type before creating it
 		if (Account.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Account.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Account.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Account.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/account/conformance.js
+++ b/src/server/profiles/account/conformance.js
@@ -8,9 +8,9 @@ const { routes } = require('./account.config');
  */
 module.exports = {
 	profile: 'account',
-	resource: (version, count) => {
-		let searchParams = generateSearchParamsForConformance(routes, version);
-		let Account = require(resolveFromVersion(version, 'base/Account'));
+	resource: (base, count) => {
+		let searchParams = generateSearchParamsForConformance(routes, base);
+		let Account = require(resolveFromVersion(base, 'base/Account'));
 		// Return our conformance statement
 		return {
 			extension: [{

--- a/src/server/profiles/activitydefinition/activitydefinition.config.js
+++ b/src/server/profiles/activitydefinition/activitydefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/activitydefinition',
+		path: '/:base/activitydefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/activitydefinition/_search',
+		path: '/:base/activitydefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/activitydefinition/:id',
+		path: '/:base/activitydefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/activitydefinition',
+		path: '/:base/activitydefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/activitydefinition/:id',
+		path: '/:base/activitydefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/activitydefinition/:id',
+		path: '/:base/activitydefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/activitydefinition/activitydefinition.controller.js
+++ b/src/server/profiles/activitydefinition/activitydefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ActivityDefinition = require(resolveFromVersion(version, 'base/ActivityDefinition'));
+		let ActivityDefinition = require(resolveFromVersion(base, 'base/ActivityDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ActivityDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, ActivityDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ActivityDefinition = require(resolveFromVersion(version, 'base/ActivityDefinition'));
+		let ActivityDefinition = require(resolveFromVersion(base, 'base/ActivityDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ActivityDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ActivityDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ActivityDefinition = require(resolveFromVersion(version, 'base/ActivityDefinition'));
+		let ActivityDefinition = require(resolveFromVersion(base, 'base/ActivityDefinition'));
 		// Validate the resource type before creating it
 		if (ActivityDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ActivityDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ActivityDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ActivityDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ActivityDefinition = require(resolveFromVersion(version, 'base/ActivityDefinition'));
+		let ActivityDefinition = require(resolveFromVersion(base, 'base/ActivityDefinition'));
 		// Validate the resource type before creating it
 		if (ActivityDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ActivityDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ActivityDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ActivityDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/adverseevent/adverseevent.config.js
+++ b/src/server/profiles/adverseevent/adverseevent.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/adverseevent',
+		path: '/:base/adverseevent',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/adverseevent/_search',
+		path: '/:base/adverseevent/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/adverseevent/:id',
+		path: '/:base/adverseevent/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/adverseevent',
+		path: '/:base/adverseevent',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/adverseevent/:id',
+		path: '/:base/adverseevent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/adverseevent/:id',
+		path: '/:base/adverseevent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/adverseevent/adverseevent.controller.js
+++ b/src/server/profiles/adverseevent/adverseevent.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AdverseEvent = require(resolveFromVersion(version, 'base/AdverseEvent'));
+		let AdverseEvent = require(resolveFromVersion(base, 'base/AdverseEvent'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, AdverseEvent, results, {
+				responseUtils.handleBundleReadResponse( res, base, AdverseEvent, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AdverseEvent = require(resolveFromVersion(version, 'base/AdverseEvent'));
+		let AdverseEvent = require(resolveFromVersion(base, 'base/AdverseEvent'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, AdverseEvent, results)
+				responseUtils.handleSingleReadResponse(res, next, base, AdverseEvent, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AdverseEvent = require(resolveFromVersion(version, 'base/AdverseEvent'));
+		let AdverseEvent = require(resolveFromVersion(base, 'base/AdverseEvent'));
 		// Validate the resource type before creating it
 		if (AdverseEvent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AdverseEvent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, AdverseEvent.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, AdverseEvent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AdverseEvent = require(resolveFromVersion(version, 'base/AdverseEvent'));
+		let AdverseEvent = require(resolveFromVersion(base, 'base/AdverseEvent'));
 		// Validate the resource type before creating it
 		if (AdverseEvent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AdverseEvent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, AdverseEvent.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, AdverseEvent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/allergyintolerance/allergyintolerance.config.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/allergyintolerance',
+		path: '/:base/allergyintolerance',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/allergyintolerance/_search',
+		path: '/:base/allergyintolerance/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/allergyintolerance/:id',
+		path: '/:base/allergyintolerance/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/allergyintolerance',
+		path: '/:base/allergyintolerance',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/allergyintolerance/:id',
+		path: '/:base/allergyintolerance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/allergyintolerance/:id',
+		path: '/:base/allergyintolerance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AllergyIntolerance = require(resolveFromVersion(version, 'uscore/AllergyIntolerance'));
+		let AllergyIntolerance = require(resolveFromVersion(base, 'uscore/AllergyIntolerance'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, AllergyIntolerance, results, {
+				responseUtils.handleBundleReadResponse( res, base, AllergyIntolerance, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AllergyIntolerance = require(resolveFromVersion(version, 'uscore/AllergyIntolerance'));
+		let AllergyIntolerance = require(resolveFromVersion(base, 'uscore/AllergyIntolerance'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, AllergyIntolerance, results)
+				responseUtils.handleSingleReadResponse(res, next, base, AllergyIntolerance, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AllergyIntolerance = require(resolveFromVersion(version, 'uscore/AllergyIntolerance'));
+		let AllergyIntolerance = require(resolveFromVersion(base, 'uscore/AllergyIntolerance'));
 		// Validate the resource type before creating it
 		if (AllergyIntolerance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AllergyIntolerance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, AllergyIntolerance.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, AllergyIntolerance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AllergyIntolerance = require(resolveFromVersion(version, 'uscore/AllergyIntolerance'));
+		let AllergyIntolerance = require(resolveFromVersion(base, 'uscore/AllergyIntolerance'));
 		// Validate the resource type before creating it
 		if (AllergyIntolerance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AllergyIntolerance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, AllergyIntolerance.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, AllergyIntolerance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/appointment/appointment.config.js
+++ b/src/server/profiles/appointment/appointment.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/appointment',
+		path: '/:base/appointment',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/appointment/_search',
+		path: '/:base/appointment/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/appointment/:id',
+		path: '/:base/appointment/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/appointment',
+		path: '/:base/appointment',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/appointment/:id',
+		path: '/:base/appointment/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/appointment/:id',
+		path: '/:base/appointment/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/appointment/appointment.controller.js
+++ b/src/server/profiles/appointment/appointment.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Appointment = require(resolveFromVersion(version, 'base/Appointment'));
+		let Appointment = require(resolveFromVersion(base, 'base/Appointment'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Appointment, results, {
+				responseUtils.handleBundleReadResponse( res, base, Appointment, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Appointment = require(resolveFromVersion(version, 'base/Appointment'));
+		let Appointment = require(resolveFromVersion(base, 'base/Appointment'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Appointment, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Appointment, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Appointment = require(resolveFromVersion(version, 'base/Appointment'));
+		let Appointment = require(resolveFromVersion(base, 'base/Appointment'));
 		// Validate the resource type before creating it
 		if (Appointment.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Appointment.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Appointment.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Appointment.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Appointment = require(resolveFromVersion(version, 'base/Appointment'));
+		let Appointment = require(resolveFromVersion(base, 'base/Appointment'));
 		// Validate the resource type before creating it
 		if (Appointment.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Appointment.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Appointment.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Appointment.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/appointmentresponse/appointmentresponse.config.js
+++ b/src/server/profiles/appointmentresponse/appointmentresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/appointmentresponse',
+		path: '/:base/appointmentresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/appointmentresponse/_search',
+		path: '/:base/appointmentresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/appointmentresponse/:id',
+		path: '/:base/appointmentresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/appointmentresponse',
+		path: '/:base/appointmentresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/appointmentresponse/:id',
+		path: '/:base/appointmentresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/appointmentresponse/:id',
+		path: '/:base/appointmentresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
+++ b/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AppointmentResponse = require(resolveFromVersion(version, 'base/AppointmentResponse'));
+		let AppointmentResponse = require(resolveFromVersion(base, 'base/AppointmentResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, AppointmentResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, AppointmentResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AppointmentResponse = require(resolveFromVersion(version, 'base/AppointmentResponse'));
+		let AppointmentResponse = require(resolveFromVersion(base, 'base/AppointmentResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, AppointmentResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, AppointmentResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AppointmentResponse = require(resolveFromVersion(version, 'base/AppointmentResponse'));
+		let AppointmentResponse = require(resolveFromVersion(base, 'base/AppointmentResponse'));
 		// Validate the resource type before creating it
 		if (AppointmentResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AppointmentResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, AppointmentResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, AppointmentResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AppointmentResponse = require(resolveFromVersion(version, 'base/AppointmentResponse'));
+		let AppointmentResponse = require(resolveFromVersion(base, 'base/AppointmentResponse'));
 		// Validate the resource type before creating it
 		if (AppointmentResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AppointmentResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, AppointmentResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, AppointmentResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/auditevent/auditevent.config.js
+++ b/src/server/profiles/auditevent/auditevent.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/auditevent',
+		path: '/:base/auditevent',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/auditevent/_search',
+		path: '/:base/auditevent/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/auditevent/:id',
+		path: '/:base/auditevent/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/auditevent',
+		path: '/:base/auditevent',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/auditevent/:id',
+		path: '/:base/auditevent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/auditevent/:id',
+		path: '/:base/auditevent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/auditevent/auditevent.controller.js
+++ b/src/server/profiles/auditevent/auditevent.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AuditEvent = require(resolveFromVersion(version, 'uscore/AuditEvent'));
+		let AuditEvent = require(resolveFromVersion(base, 'uscore/AuditEvent'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, AuditEvent, results, {
+				responseUtils.handleBundleReadResponse( res, base, AuditEvent, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let AuditEvent = require(resolveFromVersion(version, 'uscore/AuditEvent'));
+		let AuditEvent = require(resolveFromVersion(base, 'uscore/AuditEvent'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, AuditEvent, results)
+				responseUtils.handleSingleReadResponse(res, next, base, AuditEvent, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AuditEvent = require(resolveFromVersion(version, 'uscore/AuditEvent'));
+		let AuditEvent = require(resolveFromVersion(base, 'uscore/AuditEvent'));
 		// Validate the resource type before creating it
 		if (AuditEvent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AuditEvent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, AuditEvent.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, AuditEvent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let AuditEvent = require(resolveFromVersion(version, 'uscore/AuditEvent'));
+		let AuditEvent = require(resolveFromVersion(base, 'uscore/AuditEvent'));
 		// Validate the resource type before creating it
 		if (AuditEvent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${AuditEvent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, AuditEvent.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, AuditEvent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/basic/basic.config.js
+++ b/src/server/profiles/basic/basic.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/basic',
+		path: '/:base/basic',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/basic/_search',
+		path: '/:base/basic/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/basic/:id',
+		path: '/:base/basic/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/basic',
+		path: '/:base/basic',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/basic/:id',
+		path: '/:base/basic/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/basic/:id',
+		path: '/:base/basic/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/basic/basic.controller.js
+++ b/src/server/profiles/basic/basic.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Basic = require(resolveFromVersion(version, 'base/Basic'));
+		let Basic = require(resolveFromVersion(base, 'base/Basic'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Basic, results, {
+				responseUtils.handleBundleReadResponse( res, base, Basic, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Basic = require(resolveFromVersion(version, 'base/Basic'));
+		let Basic = require(resolveFromVersion(base, 'base/Basic'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Basic, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Basic, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Basic = require(resolveFromVersion(version, 'base/Basic'));
+		let Basic = require(resolveFromVersion(base, 'base/Basic'));
 		// Validate the resource type before creating it
 		if (Basic.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Basic.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Basic.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Basic.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Basic = require(resolveFromVersion(version, 'base/Basic'));
+		let Basic = require(resolveFromVersion(base, 'base/Basic'));
 		// Validate the resource type before creating it
 		if (Basic.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Basic.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Basic.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Basic.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/binary/binary.config.js
+++ b/src/server/profiles/binary/binary.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/binary',
+		path: '/:base/binary',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/binary/_search',
+		path: '/:base/binary/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/binary/:id',
+		path: '/:base/binary/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/binary',
+		path: '/:base/binary',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/binary/:id',
+		path: '/:base/binary/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/binary/:id',
+		path: '/:base/binary/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/binary/binary.controller.js
+++ b/src/server/profiles/binary/binary.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Binary = require(resolveFromVersion(version, 'base/Binary'));
+		let Binary = require(resolveFromVersion(base, 'base/Binary'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Binary, results, {
+				responseUtils.handleBundleReadResponse( res, base, Binary, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Binary = require(resolveFromVersion(version, 'base/Binary'));
+		let Binary = require(resolveFromVersion(base, 'base/Binary'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Binary, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Binary, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Binary = require(resolveFromVersion(version, 'base/Binary'));
+		let Binary = require(resolveFromVersion(base, 'base/Binary'));
 		// Validate the resource type before creating it
 		if (Binary.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Binary.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Binary.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Binary.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Binary = require(resolveFromVersion(version, 'base/Binary'));
+		let Binary = require(resolveFromVersion(base, 'base/Binary'));
 		// Validate the resource type before creating it
 		if (Binary.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Binary.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Binary.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Binary.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/bodysite/bodysite.config.js
+++ b/src/server/profiles/bodysite/bodysite.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/bodysite',
+		path: '/:base/bodysite',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/bodysite/_search',
+		path: '/:base/bodysite/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/bodysite/:id',
+		path: '/:base/bodysite/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/bodysite',
+		path: '/:base/bodysite',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/bodysite/:id',
+		path: '/:base/bodysite/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/bodysite/:id',
+		path: '/:base/bodysite/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/bodysite/bodysite.controller.js
+++ b/src/server/profiles/bodysite/bodysite.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let BodySite = require(resolveFromVersion(version, 'base/BodySite'));
+		let BodySite = require(resolveFromVersion(base, 'base/BodySite'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, BodySite, results, {
+				responseUtils.handleBundleReadResponse( res, base, BodySite, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let BodySite = require(resolveFromVersion(version, 'base/BodySite'));
+		let BodySite = require(resolveFromVersion(base, 'base/BodySite'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, BodySite, results)
+				responseUtils.handleSingleReadResponse(res, next, base, BodySite, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let BodySite = require(resolveFromVersion(version, 'base/BodySite'));
+		let BodySite = require(resolveFromVersion(base, 'base/BodySite'));
 		// Validate the resource type before creating it
 		if (BodySite.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${BodySite.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, BodySite.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, BodySite.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let BodySite = require(resolveFromVersion(version, 'base/BodySite'));
+		let BodySite = require(resolveFromVersion(base, 'base/BodySite'));
 		// Validate the resource type before creating it
 		if (BodySite.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${BodySite.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, BodySite.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, BodySite.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/bundle/bundle.config.js
+++ b/src/server/profiles/bundle/bundle.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/bundle',
+		path: '/:base/bundle',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/bundle/_search',
+		path: '/:base/bundle/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/bundle/:id',
+		path: '/:base/bundle/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/bundle',
+		path: '/:base/bundle',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/bundle/:id',
+		path: '/:base/bundle/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/bundle/:id',
+		path: '/:base/bundle/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/bundle/bundle.controller.js
+++ b/src/server/profiles/bundle/bundle.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Bundle = require(resolveFromVersion(version, 'uscore/Bundle'));
+		let Bundle = require(resolveFromVersion(base, 'uscore/Bundle'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Bundle, results, {
+				responseUtils.handleBundleReadResponse( res, base, Bundle, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Bundle = require(resolveFromVersion(version, 'uscore/Bundle'));
+		let Bundle = require(resolveFromVersion(base, 'uscore/Bundle'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Bundle, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Bundle, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Bundle = require(resolveFromVersion(version, 'uscore/Bundle'));
+		let Bundle = require(resolveFromVersion(base, 'uscore/Bundle'));
 		// Validate the resource type before creating it
 		if (Bundle.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Bundle.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Bundle.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Bundle.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Bundle = require(resolveFromVersion(version, 'uscore/Bundle'));
+		let Bundle = require(resolveFromVersion(base, 'uscore/Bundle'));
 		// Validate the resource type before creating it
 		if (Bundle.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Bundle.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Bundle.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Bundle.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/capabilitystatement/capabilitystatement.config.js
+++ b/src/server/profiles/capabilitystatement/capabilitystatement.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/capabilitystatement',
+		path: '/:base/capabilitystatement',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/capabilitystatement/_search',
+		path: '/:base/capabilitystatement/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/capabilitystatement/:id',
+		path: '/:base/capabilitystatement/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/capabilitystatement',
+		path: '/:base/capabilitystatement',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/capabilitystatement/:id',
+		path: '/:base/capabilitystatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/capabilitystatement/:id',
+		path: '/:base/capabilitystatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
+++ b/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CapabilityStatement = require(resolveFromVersion(version, 'base/CapabilityStatement'));
+		let CapabilityStatement = require(resolveFromVersion(base, 'base/CapabilityStatement'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CapabilityStatement, results, {
+				responseUtils.handleBundleReadResponse( res, base, CapabilityStatement, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CapabilityStatement = require(resolveFromVersion(version, 'base/CapabilityStatement'));
+		let CapabilityStatement = require(resolveFromVersion(base, 'base/CapabilityStatement'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CapabilityStatement, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CapabilityStatement, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CapabilityStatement = require(resolveFromVersion(version, 'base/CapabilityStatement'));
+		let CapabilityStatement = require(resolveFromVersion(base, 'base/CapabilityStatement'));
 		// Validate the resource type before creating it
 		if (CapabilityStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CapabilityStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CapabilityStatement.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CapabilityStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CapabilityStatement = require(resolveFromVersion(version, 'base/CapabilityStatement'));
+		let CapabilityStatement = require(resolveFromVersion(base, 'base/CapabilityStatement'));
 		// Validate the resource type before creating it
 		if (CapabilityStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CapabilityStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CapabilityStatement.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CapabilityStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/careplan/careplan.config.js
+++ b/src/server/profiles/careplan/careplan.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/careplan',
+		path: '/:base/careplan',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/careplan/_search',
+		path: '/:base/careplan/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/careplan/:id',
+		path: '/:base/careplan/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/careplan',
+		path: '/:base/careplan',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/careplan/:id',
+		path: '/:base/careplan/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/careplan/:id',
+		path: '/:base/careplan/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/careplan/careplan.controller.js
+++ b/src/server/profiles/careplan/careplan.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific careplan
-		let CarePlan = require(resolveFromVersion(version, 'uscore/CarePlan'));
+		let CarePlan = require(resolveFromVersion(base, 'uscore/CarePlan'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CarePlan, results, {
+				responseUtils.handleBundleReadResponse( res, base, CarePlan, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific careplan
-		let CarePlan = require(resolveFromVersion(version, 'uscore/CarePlan'));
+		let CarePlan = require(resolveFromVersion(base, 'uscore/CarePlan'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CarePlan, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CarePlan, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific care_plan
-		let CarePlan = require(resolveFromVersion(version, 'uscore/CarePlan'));
+		let CarePlan = require(resolveFromVersion(base, 'uscore/CarePlan'));
 		// Validate the resource type before creating it
 		if (CarePlan.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CarePlan.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new care_plan resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CarePlan.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CarePlan.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific care_plan
-		let CarePlan = require(resolveFromVersion(version, 'uscore/CarePlan'));
+		let CarePlan = require(resolveFromVersion(base, 'uscore/CarePlan'));
 		// Validate the resource type before creating it
 		if (CarePlan.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CarePlan.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new care_plan resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CarePlan.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CarePlan.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/careteam/careteam.config.js
+++ b/src/server/profiles/careteam/careteam.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/careteam',
+		path: '/:base/careteam',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/careteam/_search',
+		path: '/:base/careteam/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/careteam/:id',
+		path: '/:base/careteam/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/careteam',
+		path: '/:base/careteam',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/careteam/:id',
+		path: '/:base/careteam/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/careteam/:id',
+		path: '/:base/careteam/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/careteam/careteam.controller.js
+++ b/src/server/profiles/careteam/careteam.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific careteam
-		let CareTeam = require(resolveFromVersion(version, 'uscore/CareTeam'));
+		let CareTeam = require(resolveFromVersion(base, 'uscore/CareTeam'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CareTeam, results, {
+				responseUtils.handleBundleReadResponse( res, base, CareTeam, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific careteam
-		let CareTeam = require(resolveFromVersion(version, 'uscore/CareTeam'));
+		let CareTeam = require(resolveFromVersion(base, 'uscore/CareTeam'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CareTeam, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CareTeam, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific care_team
-		let CareTeam = require(resolveFromVersion(version, 'uscore/CareTeam'));
+		let CareTeam = require(resolveFromVersion(base, 'uscore/CareTeam'));
 		// Validate the resource type before creating it
 		if (CareTeam.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CareTeam.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new care_team resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CareTeam.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CareTeam.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific care_team
-		let CareTeam = require(resolveFromVersion(version, 'uscore/CareTeam'));
+		let CareTeam = require(resolveFromVersion(base, 'uscore/CareTeam'));
 		// Validate the resource type before creating it
 		if (CareTeam.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CareTeam.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new care_team resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CareTeam.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CareTeam.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/chargeitem/chargeitem.config.js
+++ b/src/server/profiles/chargeitem/chargeitem.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/chargeitem',
+		path: '/:base/chargeitem',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/chargeitem/_search',
+		path: '/:base/chargeitem/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/chargeitem/:id',
+		path: '/:base/chargeitem/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/chargeitem',
+		path: '/:base/chargeitem',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/chargeitem/:id',
+		path: '/:base/chargeitem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/chargeitem/:id',
+		path: '/:base/chargeitem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/chargeitem/chargeitem.controller.js
+++ b/src/server/profiles/chargeitem/chargeitem.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ChargeItem = require(resolveFromVersion(version, 'base/ChargeItem'));
+		let ChargeItem = require(resolveFromVersion(base, 'base/ChargeItem'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ChargeItem, results, {
+				responseUtils.handleBundleReadResponse( res, base, ChargeItem, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ChargeItem = require(resolveFromVersion(version, 'base/ChargeItem'));
+		let ChargeItem = require(resolveFromVersion(base, 'base/ChargeItem'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ChargeItem, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ChargeItem, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ChargeItem = require(resolveFromVersion(version, 'base/ChargeItem'));
+		let ChargeItem = require(resolveFromVersion(base, 'base/ChargeItem'));
 		// Validate the resource type before creating it
 		if (ChargeItem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ChargeItem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ChargeItem.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ChargeItem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ChargeItem = require(resolveFromVersion(version, 'base/ChargeItem'));
+		let ChargeItem = require(resolveFromVersion(base, 'base/ChargeItem'));
 		// Validate the resource type before creating it
 		if (ChargeItem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ChargeItem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ChargeItem.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ChargeItem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/claim/claim.config.js
+++ b/src/server/profiles/claim/claim.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/claim',
+		path: '/:base/claim',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/claim/_search',
+		path: '/:base/claim/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/claim/:id',
+		path: '/:base/claim/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/claim',
+		path: '/:base/claim',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/claim/:id',
+		path: '/:base/claim/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/claim/:id',
+		path: '/:base/claim/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/claim/claim.controller.js
+++ b/src/server/profiles/claim/claim.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Claim = require(resolveFromVersion(version, 'base/Claim'));
+		let Claim = require(resolveFromVersion(base, 'base/Claim'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Claim, results, {
+				responseUtils.handleBundleReadResponse( res, base, Claim, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Claim = require(resolveFromVersion(version, 'base/Claim'));
+		let Claim = require(resolveFromVersion(base, 'base/Claim'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Claim, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Claim, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Claim = require(resolveFromVersion(version, 'base/Claim'));
+		let Claim = require(resolveFromVersion(base, 'base/Claim'));
 		// Validate the resource type before creating it
 		if (Claim.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Claim.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Claim.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Claim.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Claim = require(resolveFromVersion(version, 'base/Claim'));
+		let Claim = require(resolveFromVersion(base, 'base/Claim'));
 		// Validate the resource type before creating it
 		if (Claim.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Claim.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Claim.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Claim.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/claimresponse/claimresponse.config.js
+++ b/src/server/profiles/claimresponse/claimresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/claimresponse',
+		path: '/:base/claimresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/claimresponse/_search',
+		path: '/:base/claimresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/claimresponse/:id',
+		path: '/:base/claimresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/claimresponse',
+		path: '/:base/claimresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/claimresponse/:id',
+		path: '/:base/claimresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/claimresponse/:id',
+		path: '/:base/claimresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/claimresponse/claimresponse.controller.js
+++ b/src/server/profiles/claimresponse/claimresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ClaimResponse = require(resolveFromVersion(version, 'base/ClaimResponse'));
+		let ClaimResponse = require(resolveFromVersion(base, 'base/ClaimResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ClaimResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, ClaimResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ClaimResponse = require(resolveFromVersion(version, 'base/ClaimResponse'));
+		let ClaimResponse = require(resolveFromVersion(base, 'base/ClaimResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ClaimResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ClaimResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ClaimResponse = require(resolveFromVersion(version, 'base/ClaimResponse'));
+		let ClaimResponse = require(resolveFromVersion(base, 'base/ClaimResponse'));
 		// Validate the resource type before creating it
 		if (ClaimResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ClaimResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ClaimResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ClaimResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ClaimResponse = require(resolveFromVersion(version, 'base/ClaimResponse'));
+		let ClaimResponse = require(resolveFromVersion(base, 'base/ClaimResponse'));
 		// Validate the resource type before creating it
 		if (ClaimResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ClaimResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ClaimResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ClaimResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/clinicalimpression/clinicalimpression.config.js
+++ b/src/server/profiles/clinicalimpression/clinicalimpression.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/clinicalimpression',
+		path: '/:base/clinicalimpression',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/clinicalimpression/_search',
+		path: '/:base/clinicalimpression/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/clinicalimpression/:id',
+		path: '/:base/clinicalimpression/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/clinicalimpression',
+		path: '/:base/clinicalimpression',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/clinicalimpression/:id',
+		path: '/:base/clinicalimpression/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/clinicalimpression/:id',
+		path: '/:base/clinicalimpression/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
+++ b/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ClinicalImpression = require(resolveFromVersion(version, 'base/ClinicalImpression'));
+		let ClinicalImpression = require(resolveFromVersion(base, 'base/ClinicalImpression'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ClinicalImpression, results, {
+				responseUtils.handleBundleReadResponse( res, base, ClinicalImpression, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ClinicalImpression = require(resolveFromVersion(version, 'base/ClinicalImpression'));
+		let ClinicalImpression = require(resolveFromVersion(base, 'base/ClinicalImpression'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ClinicalImpression, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ClinicalImpression, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ClinicalImpression = require(resolveFromVersion(version, 'base/ClinicalImpression'));
+		let ClinicalImpression = require(resolveFromVersion(base, 'base/ClinicalImpression'));
 		// Validate the resource type before creating it
 		if (ClinicalImpression.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ClinicalImpression.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ClinicalImpression.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ClinicalImpression.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ClinicalImpression = require(resolveFromVersion(version, 'base/ClinicalImpression'));
+		let ClinicalImpression = require(resolveFromVersion(base, 'base/ClinicalImpression'));
 		// Validate the resource type before creating it
 		if (ClinicalImpression.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ClinicalImpression.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ClinicalImpression.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ClinicalImpression.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/codesystem/codesystem.config.js
+++ b/src/server/profiles/codesystem/codesystem.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/codesystem',
+		path: '/:base/codesystem',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/codesystem/_search',
+		path: '/:base/codesystem/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/codesystem/:id',
+		path: '/:base/codesystem/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/codesystem',
+		path: '/:base/codesystem',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/codesystem/:id',
+		path: '/:base/codesystem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/codesystem/:id',
+		path: '/:base/codesystem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/codesystem/codesystem.controller.js
+++ b/src/server/profiles/codesystem/codesystem.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CodeSystem = require(resolveFromVersion(version, 'base/CodeSystem'));
+		let CodeSystem = require(resolveFromVersion(base, 'base/CodeSystem'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CodeSystem, results, {
+				responseUtils.handleBundleReadResponse( res, base, CodeSystem, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CodeSystem = require(resolveFromVersion(version, 'base/CodeSystem'));
+		let CodeSystem = require(resolveFromVersion(base, 'base/CodeSystem'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CodeSystem, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CodeSystem, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CodeSystem = require(resolveFromVersion(version, 'base/CodeSystem'));
+		let CodeSystem = require(resolveFromVersion(base, 'base/CodeSystem'));
 		// Validate the resource type before creating it
 		if (CodeSystem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CodeSystem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CodeSystem.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CodeSystem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CodeSystem = require(resolveFromVersion(version, 'base/CodeSystem'));
+		let CodeSystem = require(resolveFromVersion(base, 'base/CodeSystem'));
 		// Validate the resource type before creating it
 		if (CodeSystem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CodeSystem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CodeSystem.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CodeSystem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/common.arguments.js
+++ b/src/server/profiles/common.arguments.js
@@ -3,8 +3,8 @@
 * @description Common express arguments used on many routes as route params
 */
 module.exports.route_args = {
-	VERSION: {
-		name: 'version',
+	BASE: {
+		name: 'base',
 		type: 'string',
 		conformance_hide: true
 	},

--- a/src/server/profiles/communication/communication.config.js
+++ b/src/server/profiles/communication/communication.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/communication',
+		path: '/:base/communication',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/communication/_search',
+		path: '/:base/communication/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/communication/:id',
+		path: '/:base/communication/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/communication',
+		path: '/:base/communication',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/communication/:id',
+		path: '/:base/communication/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/communication/:id',
+		path: '/:base/communication/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/communication/communication.controller.js
+++ b/src/server/profiles/communication/communication.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Communication = require(resolveFromVersion(version, 'base/Communication'));
+		let Communication = require(resolveFromVersion(base, 'base/Communication'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Communication, results, {
+				responseUtils.handleBundleReadResponse( res, base, Communication, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Communication = require(resolveFromVersion(version, 'base/Communication'));
+		let Communication = require(resolveFromVersion(base, 'base/Communication'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Communication, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Communication, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Communication = require(resolveFromVersion(version, 'base/Communication'));
+		let Communication = require(resolveFromVersion(base, 'base/Communication'));
 		// Validate the resource type before creating it
 		if (Communication.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Communication.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Communication.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Communication.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Communication = require(resolveFromVersion(version, 'base/Communication'));
+		let Communication = require(resolveFromVersion(base, 'base/Communication'));
 		// Validate the resource type before creating it
 		if (Communication.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Communication.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Communication.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Communication.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/communicationrequest/communicationrequest.config.js
+++ b/src/server/profiles/communicationrequest/communicationrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/communicationrequest',
+		path: '/:base/communicationrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/communicationrequest/_search',
+		path: '/:base/communicationrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/communicationrequest/:id',
+		path: '/:base/communicationrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/communicationrequest',
+		path: '/:base/communicationrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/communicationrequest/:id',
+		path: '/:base/communicationrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/communicationrequest/:id',
+		path: '/:base/communicationrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/communicationrequest/communicationrequest.controller.js
+++ b/src/server/profiles/communicationrequest/communicationrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CommunicationRequest = require(resolveFromVersion(version, 'base/CommunicationRequest'));
+		let CommunicationRequest = require(resolveFromVersion(base, 'base/CommunicationRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CommunicationRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, CommunicationRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CommunicationRequest = require(resolveFromVersion(version, 'base/CommunicationRequest'));
+		let CommunicationRequest = require(resolveFromVersion(base, 'base/CommunicationRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CommunicationRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CommunicationRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CommunicationRequest = require(resolveFromVersion(version, 'base/CommunicationRequest'));
+		let CommunicationRequest = require(resolveFromVersion(base, 'base/CommunicationRequest'));
 		// Validate the resource type before creating it
 		if (CommunicationRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CommunicationRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CommunicationRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CommunicationRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CommunicationRequest = require(resolveFromVersion(version, 'base/CommunicationRequest'));
+		let CommunicationRequest = require(resolveFromVersion(base, 'base/CommunicationRequest'));
 		// Validate the resource type before creating it
 		if (CommunicationRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CommunicationRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CommunicationRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CommunicationRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/compartmentdefinition/compartmentdefinition.config.js
+++ b/src/server/profiles/compartmentdefinition/compartmentdefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/compartmentdefinition',
+		path: '/:base/compartmentdefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/compartmentdefinition/_search',
+		path: '/:base/compartmentdefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/compartmentdefinition/:id',
+		path: '/:base/compartmentdefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/compartmentdefinition',
+		path: '/:base/compartmentdefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/compartmentdefinition/:id',
+		path: '/:base/compartmentdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/compartmentdefinition/:id',
+		path: '/:base/compartmentdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
+++ b/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CompartmentDefinition = require(resolveFromVersion(version, 'base/CompartmentDefinition'));
+		let CompartmentDefinition = require(resolveFromVersion(base, 'base/CompartmentDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, CompartmentDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, CompartmentDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let CompartmentDefinition = require(resolveFromVersion(version, 'base/CompartmentDefinition'));
+		let CompartmentDefinition = require(resolveFromVersion(base, 'base/CompartmentDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, CompartmentDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, CompartmentDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CompartmentDefinition = require(resolveFromVersion(version, 'base/CompartmentDefinition'));
+		let CompartmentDefinition = require(resolveFromVersion(base, 'base/CompartmentDefinition'));
 		// Validate the resource type before creating it
 		if (CompartmentDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CompartmentDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, CompartmentDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, CompartmentDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let CompartmentDefinition = require(resolveFromVersion(version, 'base/CompartmentDefinition'));
+		let CompartmentDefinition = require(resolveFromVersion(base, 'base/CompartmentDefinition'));
 		// Validate the resource type before creating it
 		if (CompartmentDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${CompartmentDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, CompartmentDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, CompartmentDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/composition/composition.config.js
+++ b/src/server/profiles/composition/composition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/composition',
+		path: '/:base/composition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/composition/_search',
+		path: '/:base/composition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/composition/:id',
+		path: '/:base/composition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/composition',
+		path: '/:base/composition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/composition/:id',
+		path: '/:base/composition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/composition/:id',
+		path: '/:base/composition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/composition/composition.controller.js
+++ b/src/server/profiles/composition/composition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Composition = require(resolveFromVersion(version, 'base/Composition'));
+		let Composition = require(resolveFromVersion(base, 'base/Composition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Composition, results, {
+				responseUtils.handleBundleReadResponse( res, base, Composition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Composition = require(resolveFromVersion(version, 'base/Composition'));
+		let Composition = require(resolveFromVersion(base, 'base/Composition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Composition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Composition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Composition = require(resolveFromVersion(version, 'base/Composition'));
+		let Composition = require(resolveFromVersion(base, 'base/Composition'));
 		// Validate the resource type before creating it
 		if (Composition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Composition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Composition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Composition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Composition = require(resolveFromVersion(version, 'base/Composition'));
+		let Composition = require(resolveFromVersion(base, 'base/Composition'));
 		// Validate the resource type before creating it
 		if (Composition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Composition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Composition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Composition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/conceptmap/conceptmap.config.js
+++ b/src/server/profiles/conceptmap/conceptmap.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/conceptmap',
+		path: '/:base/conceptmap',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/conceptmap/_search',
+		path: '/:base/conceptmap/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/conceptmap/:id',
+		path: '/:base/conceptmap/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/conceptmap',
+		path: '/:base/conceptmap',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/conceptmap/:id',
+		path: '/:base/conceptmap/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/conceptmap/:id',
+		path: '/:base/conceptmap/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/conceptmap/conceptmap.controller.js
+++ b/src/server/profiles/conceptmap/conceptmap.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ConceptMap = require(resolveFromVersion(version, 'base/ConceptMap'));
+		let ConceptMap = require(resolveFromVersion(base, 'base/ConceptMap'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ConceptMap, results, {
+				responseUtils.handleBundleReadResponse( res, base, ConceptMap, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ConceptMap = require(resolveFromVersion(version, 'base/ConceptMap'));
+		let ConceptMap = require(resolveFromVersion(base, 'base/ConceptMap'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ConceptMap, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ConceptMap, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ConceptMap = require(resolveFromVersion(version, 'base/ConceptMap'));
+		let ConceptMap = require(resolveFromVersion(base, 'base/ConceptMap'));
 		// Validate the resource type before creating it
 		if (ConceptMap.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ConceptMap.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ConceptMap.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ConceptMap.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ConceptMap = require(resolveFromVersion(version, 'base/ConceptMap'));
+		let ConceptMap = require(resolveFromVersion(base, 'base/ConceptMap'));
 		// Validate the resource type before creating it
 		if (ConceptMap.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ConceptMap.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ConceptMap.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ConceptMap.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/condition/condition.config.js
+++ b/src/server/profiles/condition/condition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/condition',
+		path: '/:base/condition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/condition/_search',
+		path: '/:base/condition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/condition/:id',
+		path: '/:base/condition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/condition',
+		path: '/:base/condition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/condition/:id',
+		path: '/:base/condition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/condition/:id',
+		path: '/:base/condition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/condition/condition.controller.js
+++ b/src/server/profiles/condition/condition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific condition
-		let Condition = require(resolveFromVersion(version, 'uscore/Condition'));
+		let Condition = require(resolveFromVersion(base, 'uscore/Condition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Condition, results, {
+				responseUtils.handleBundleReadResponse( res, base, Condition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific condition
-		let Condition = require(resolveFromVersion(version, 'uscore/Condition'));
+		let Condition = require(resolveFromVersion(base, 'uscore/Condition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Condition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Condition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific condition
-		let Condition = require(resolveFromVersion(version, 'uscore/Condition'));
+		let Condition = require(resolveFromVersion(base, 'uscore/Condition'));
 		// Validate the resource type before creating it
 		if (Condition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Condition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new condition resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Condition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Condition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific condition
-		let Condition = require(resolveFromVersion(version, 'uscore/Condition'));
+		let Condition = require(resolveFromVersion(base, 'uscore/Condition'));
 		// Validate the resource type before creating it
 		if (Condition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Condition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new condition resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Condition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Condition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/consent/consent.config.js
+++ b/src/server/profiles/consent/consent.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/consent',
+		path: '/:base/consent',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/consent/_search',
+		path: '/:base/consent/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/consent/:id',
+		path: '/:base/consent/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/consent',
+		path: '/:base/consent',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/consent/:id',
+		path: '/:base/consent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/consent/:id',
+		path: '/:base/consent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/consent/consent.controller.js
+++ b/src/server/profiles/consent/consent.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Consent = require(resolveFromVersion(version, 'uscore/Consent'));
+		let Consent = require(resolveFromVersion(base, 'uscore/Consent'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Consent, results, {
+				responseUtils.handleBundleReadResponse( res, base, Consent, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Consent = require(resolveFromVersion(version, 'uscore/Consent'));
+		let Consent = require(resolveFromVersion(base, 'uscore/Consent'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Consent, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Consent, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Consent = require(resolveFromVersion(version, 'uscore/Consent'));
+		let Consent = require(resolveFromVersion(base, 'uscore/Consent'));
 		// Validate the resource type before creating it
 		if (Consent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Consent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Consent.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Consent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Consent = require(resolveFromVersion(version, 'uscore/Consent'));
+		let Consent = require(resolveFromVersion(base, 'uscore/Consent'));
 		// Validate the resource type before creating it
 		if (Consent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Consent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Consent.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Consent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/contract/contract.config.js
+++ b/src/server/profiles/contract/contract.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/contract',
+		path: '/:base/contract',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/contract/_search',
+		path: '/:base/contract/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/contract/:id',
+		path: '/:base/contract/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/contract',
+		path: '/:base/contract',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/contract/:id',
+		path: '/:base/contract/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/contract/:id',
+		path: '/:base/contract/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/contract/contract.controller.js
+++ b/src/server/profiles/contract/contract.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Contract = require(resolveFromVersion(version, 'base/Contract'));
+		let Contract = require(resolveFromVersion(base, 'base/Contract'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Contract, results, {
+				responseUtils.handleBundleReadResponse( res, base, Contract, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Contract = require(resolveFromVersion(version, 'base/Contract'));
+		let Contract = require(resolveFromVersion(base, 'base/Contract'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Contract, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Contract, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Contract = require(resolveFromVersion(version, 'base/Contract'));
+		let Contract = require(resolveFromVersion(base, 'base/Contract'));
 		// Validate the resource type before creating it
 		if (Contract.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Contract.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Contract.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Contract.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Contract = require(resolveFromVersion(version, 'base/Contract'));
+		let Contract = require(resolveFromVersion(base, 'base/Contract'));
 		// Validate the resource type before creating it
 		if (Contract.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Contract.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Contract.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Contract.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/coverage/coverage.config.js
+++ b/src/server/profiles/coverage/coverage.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/coverage',
+		path: '/:base/coverage',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/coverage/_search',
+		path: '/:base/coverage/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/coverage/:id',
+		path: '/:base/coverage/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/coverage',
+		path: '/:base/coverage',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/coverage/:id',
+		path: '/:base/coverage/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/coverage/:id',
+		path: '/:base/coverage/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/coverage/coverage.controller.js
+++ b/src/server/profiles/coverage/coverage.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Coverage = require(resolveFromVersion(version, 'base/Coverage'));
+		let Coverage = require(resolveFromVersion(base, 'base/Coverage'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Coverage, results, {
+				responseUtils.handleBundleReadResponse( res, base, Coverage, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Coverage = require(resolveFromVersion(version, 'base/Coverage'));
+		let Coverage = require(resolveFromVersion(base, 'base/Coverage'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Coverage, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Coverage, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Coverage = require(resolveFromVersion(version, 'base/Coverage'));
+		let Coverage = require(resolveFromVersion(base, 'base/Coverage'));
 		// Validate the resource type before creating it
 		if (Coverage.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Coverage.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Coverage.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Coverage.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Coverage = require(resolveFromVersion(version, 'base/Coverage'));
+		let Coverage = require(resolveFromVersion(base, 'base/Coverage'));
 		// Validate the resource type before creating it
 		if (Coverage.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Coverage.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Coverage.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Coverage.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/dataelement/dataelement.config.js
+++ b/src/server/profiles/dataelement/dataelement.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/dataelement',
+		path: '/:base/dataelement',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/dataelement/_search',
+		path: '/:base/dataelement/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/dataelement/:id',
+		path: '/:base/dataelement/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/dataelement',
+		path: '/:base/dataelement',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/dataelement/:id',
+		path: '/:base/dataelement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/dataelement/:id',
+		path: '/:base/dataelement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/dataelement/dataelement.controller.js
+++ b/src/server/profiles/dataelement/dataelement.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DataElement = require(resolveFromVersion(version, 'base/DataElement'));
+		let DataElement = require(resolveFromVersion(base, 'base/DataElement'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DataElement, results, {
+				responseUtils.handleBundleReadResponse( res, base, DataElement, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DataElement = require(resolveFromVersion(version, 'base/DataElement'));
+		let DataElement = require(resolveFromVersion(base, 'base/DataElement'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DataElement, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DataElement, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DataElement = require(resolveFromVersion(version, 'base/DataElement'));
+		let DataElement = require(resolveFromVersion(base, 'base/DataElement'));
 		// Validate the resource type before creating it
 		if (DataElement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DataElement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DataElement.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DataElement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DataElement = require(resolveFromVersion(version, 'base/DataElement'));
+		let DataElement = require(resolveFromVersion(base, 'base/DataElement'));
 		// Validate the resource type before creating it
 		if (DataElement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DataElement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DataElement.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DataElement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/detectedissue/detectedissue.config.js
+++ b/src/server/profiles/detectedissue/detectedissue.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/detectedissue',
+		path: '/:base/detectedissue',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/detectedissue/_search',
+		path: '/:base/detectedissue/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/detectedissue/:id',
+		path: '/:base/detectedissue/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/detectedissue',
+		path: '/:base/detectedissue',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/detectedissue/:id',
+		path: '/:base/detectedissue/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/detectedissue/:id',
+		path: '/:base/detectedissue/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/detectedissue/detectedissue.controller.js
+++ b/src/server/profiles/detectedissue/detectedissue.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DetectedIssue = require(resolveFromVersion(version, 'base/DetectedIssue'));
+		let DetectedIssue = require(resolveFromVersion(base, 'base/DetectedIssue'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DetectedIssue, results, {
+				responseUtils.handleBundleReadResponse( res, base, DetectedIssue, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DetectedIssue = require(resolveFromVersion(version, 'base/DetectedIssue'));
+		let DetectedIssue = require(resolveFromVersion(base, 'base/DetectedIssue'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DetectedIssue, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DetectedIssue, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DetectedIssue = require(resolveFromVersion(version, 'base/DetectedIssue'));
+		let DetectedIssue = require(resolveFromVersion(base, 'base/DetectedIssue'));
 		// Validate the resource type before creating it
 		if (DetectedIssue.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DetectedIssue.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DetectedIssue.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DetectedIssue.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DetectedIssue = require(resolveFromVersion(version, 'base/DetectedIssue'));
+		let DetectedIssue = require(resolveFromVersion(base, 'base/DetectedIssue'));
 		// Validate the resource type before creating it
 		if (DetectedIssue.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DetectedIssue.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DetectedIssue.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DetectedIssue.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/device/device.config.js
+++ b/src/server/profiles/device/device.config.js
@@ -15,29 +15,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/device',
+		path: '/:base/device',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/device/_search',
+		path: '/:base/device/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/device/:id',
+		path: '/:base/device/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -45,9 +45,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/device',
+		path: '/:base/device',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -56,10 +56,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/device/:id',
+		path: '/:base/device/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -67,10 +67,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/device/:id',
+		path: '/:base/device/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/device/device.controller.js
+++ b/src/server/profiles/device/device.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific device
-		let Device = require(resolveFromVersion(version, 'uscore/Device'));
+		let Device = require(resolveFromVersion(base, 'uscore/Device'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Device, results, {
+				responseUtils.handleBundleReadResponse( res, base, Device, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific device
-		let Device = require(resolveFromVersion(version, 'uscore/Device'));
+		let Device = require(resolveFromVersion(base, 'uscore/Device'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Device, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Device, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific device
-		let Device = require(resolveFromVersion(version, 'uscore/Device'));
+		let Device = require(resolveFromVersion(base, 'uscore/Device'));
 		// Validate the resource type before creating it
 		if (Device.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Device.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new device resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Device.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Device.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific device
-		let Device = require(resolveFromVersion(version, 'uscore/Device'));
+		let Device = require(resolveFromVersion(base, 'uscore/Device'));
 		// Validate the resource type before creating it
 		if (Device.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Device.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new device resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Device.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Device.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/devicecomponent/devicecomponent.config.js
+++ b/src/server/profiles/devicecomponent/devicecomponent.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/devicecomponent',
+		path: '/:base/devicecomponent',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/devicecomponent/_search',
+		path: '/:base/devicecomponent/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/devicecomponent/:id',
+		path: '/:base/devicecomponent/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/devicecomponent',
+		path: '/:base/devicecomponent',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/devicecomponent/:id',
+		path: '/:base/devicecomponent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/devicecomponent/:id',
+		path: '/:base/devicecomponent/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/devicecomponent/devicecomponent.controller.js
+++ b/src/server/profiles/devicecomponent/devicecomponent.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceComponent = require(resolveFromVersion(version, 'base/DeviceComponent'));
+		let DeviceComponent = require(resolveFromVersion(base, 'base/DeviceComponent'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DeviceComponent, results, {
+				responseUtils.handleBundleReadResponse( res, base, DeviceComponent, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceComponent = require(resolveFromVersion(version, 'base/DeviceComponent'));
+		let DeviceComponent = require(resolveFromVersion(base, 'base/DeviceComponent'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DeviceComponent, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DeviceComponent, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceComponent = require(resolveFromVersion(version, 'base/DeviceComponent'));
+		let DeviceComponent = require(resolveFromVersion(base, 'base/DeviceComponent'));
 		// Validate the resource type before creating it
 		if (DeviceComponent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceComponent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DeviceComponent.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DeviceComponent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceComponent = require(resolveFromVersion(version, 'base/DeviceComponent'));
+		let DeviceComponent = require(resolveFromVersion(base, 'base/DeviceComponent'));
 		// Validate the resource type before creating it
 		if (DeviceComponent.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceComponent.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DeviceComponent.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DeviceComponent.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/devicemetric/devicemetric.config.js
+++ b/src/server/profiles/devicemetric/devicemetric.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/devicemetric',
+		path: '/:base/devicemetric',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/devicemetric/_search',
+		path: '/:base/devicemetric/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/devicemetric/:id',
+		path: '/:base/devicemetric/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/devicemetric',
+		path: '/:base/devicemetric',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/devicemetric/:id',
+		path: '/:base/devicemetric/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/devicemetric/:id',
+		path: '/:base/devicemetric/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/devicemetric/devicemetric.controller.js
+++ b/src/server/profiles/devicemetric/devicemetric.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceMetric = require(resolveFromVersion(version, 'base/DeviceMetric'));
+		let DeviceMetric = require(resolveFromVersion(base, 'base/DeviceMetric'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DeviceMetric, results, {
+				responseUtils.handleBundleReadResponse( res, base, DeviceMetric, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceMetric = require(resolveFromVersion(version, 'base/DeviceMetric'));
+		let DeviceMetric = require(resolveFromVersion(base, 'base/DeviceMetric'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DeviceMetric, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DeviceMetric, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceMetric = require(resolveFromVersion(version, 'base/DeviceMetric'));
+		let DeviceMetric = require(resolveFromVersion(base, 'base/DeviceMetric'));
 		// Validate the resource type before creating it
 		if (DeviceMetric.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceMetric.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DeviceMetric.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DeviceMetric.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceMetric = require(resolveFromVersion(version, 'base/DeviceMetric'));
+		let DeviceMetric = require(resolveFromVersion(base, 'base/DeviceMetric'));
 		// Validate the resource type before creating it
 		if (DeviceMetric.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceMetric.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DeviceMetric.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DeviceMetric.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/devicerequest/devicerequest.config.js
+++ b/src/server/profiles/devicerequest/devicerequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/devicerequest',
+		path: '/:base/devicerequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/devicerequest/_search',
+		path: '/:base/devicerequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/devicerequest/:id',
+		path: '/:base/devicerequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/devicerequest',
+		path: '/:base/devicerequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/devicerequest/:id',
+		path: '/:base/devicerequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/devicerequest/:id',
+		path: '/:base/devicerequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/devicerequest/devicerequest.controller.js
+++ b/src/server/profiles/devicerequest/devicerequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceRequest = require(resolveFromVersion(version, 'base/DeviceRequest'));
+		let DeviceRequest = require(resolveFromVersion(base, 'base/DeviceRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DeviceRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, DeviceRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceRequest = require(resolveFromVersion(version, 'base/DeviceRequest'));
+		let DeviceRequest = require(resolveFromVersion(base, 'base/DeviceRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DeviceRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DeviceRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceRequest = require(resolveFromVersion(version, 'base/DeviceRequest'));
+		let DeviceRequest = require(resolveFromVersion(base, 'base/DeviceRequest'));
 		// Validate the resource type before creating it
 		if (DeviceRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DeviceRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DeviceRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceRequest = require(resolveFromVersion(version, 'base/DeviceRequest'));
+		let DeviceRequest = require(resolveFromVersion(base, 'base/DeviceRequest'));
 		// Validate the resource type before creating it
 		if (DeviceRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DeviceRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DeviceRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/deviceusestatement/deviceusestatement.config.js
+++ b/src/server/profiles/deviceusestatement/deviceusestatement.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/deviceusestatement',
+		path: '/:base/deviceusestatement',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/deviceusestatement/_search',
+		path: '/:base/deviceusestatement/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/deviceusestatement/:id',
+		path: '/:base/deviceusestatement/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/deviceusestatement',
+		path: '/:base/deviceusestatement',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/deviceusestatement/:id',
+		path: '/:base/deviceusestatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/deviceusestatement/:id',
+		path: '/:base/deviceusestatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
+++ b/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceUseStatement = require(resolveFromVersion(version, 'base/DeviceUseStatement'));
+		let DeviceUseStatement = require(resolveFromVersion(base, 'base/DeviceUseStatement'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DeviceUseStatement, results, {
+				responseUtils.handleBundleReadResponse( res, base, DeviceUseStatement, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceUseStatement = require(resolveFromVersion(version, 'base/DeviceUseStatement'));
+		let DeviceUseStatement = require(resolveFromVersion(base, 'base/DeviceUseStatement'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DeviceUseStatement, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DeviceUseStatement, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceUseStatement = require(resolveFromVersion(version, 'base/DeviceUseStatement'));
+		let DeviceUseStatement = require(resolveFromVersion(base, 'base/DeviceUseStatement'));
 		// Validate the resource type before creating it
 		if (DeviceUseStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceUseStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DeviceUseStatement.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DeviceUseStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DeviceUseStatement = require(resolveFromVersion(version, 'base/DeviceUseStatement'));
+		let DeviceUseStatement = require(resolveFromVersion(base, 'base/DeviceUseStatement'));
 		// Validate the resource type before creating it
 		if (DeviceUseStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DeviceUseStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DeviceUseStatement.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DeviceUseStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/diagnosticreport/diagnosticreport.config.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.config.js
@@ -16,29 +16,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/diagnosticreport',
+		path: '/:base/diagnosticreport',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/diagnosticreport/_search',
+		path: '/:base/diagnosticreport/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/diagnosticreport/:id',
+		path: '/:base/diagnosticreport/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -46,9 +46,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/diagnosticreport',
+		path: '/:base/diagnosticreport',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -57,10 +57,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/diagnosticreport/:id',
+		path: '/:base/diagnosticreport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -68,10 +68,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/diagnosticreport/:id',
+		path: '/:base/diagnosticreport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific diagnosticreport
-		let DiagnosticReport = require(resolveFromVersion(version, 'uscore/DiagnosticReport'));
+		let DiagnosticReport = require(resolveFromVersion(base, 'uscore/DiagnosticReport'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DiagnosticReport, results, {
+				responseUtils.handleBundleReadResponse( res, base, DiagnosticReport, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific diagnosticreport
-		let DiagnosticReport = require(resolveFromVersion(version, 'uscore/DiagnosticReport'));
+		let DiagnosticReport = require(resolveFromVersion(base, 'uscore/DiagnosticReport'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DiagnosticReport, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DiagnosticReport, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific diagnostic_report
-		let DiagnosticReport = require(resolveFromVersion(version, 'uscore/DiagnosticReport'));
+		let DiagnosticReport = require(resolveFromVersion(base, 'uscore/DiagnosticReport'));
 		// Validate the resource type before creating it
 		if (DiagnosticReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DiagnosticReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new diagnostic_report resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DiagnosticReport.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DiagnosticReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific diagnostic_report
-		let DiagnosticReport = require(resolveFromVersion(version, 'uscore/DiagnosticReport'));
+		let DiagnosticReport = require(resolveFromVersion(base, 'uscore/DiagnosticReport'));
 		// Validate the resource type before creating it
 		if (DiagnosticReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DiagnosticReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new diagnostic_report resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DiagnosticReport.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DiagnosticReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/documentmanifest/documentmanifest.config.js
+++ b/src/server/profiles/documentmanifest/documentmanifest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/documentmanifest',
+		path: '/:base/documentmanifest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/documentmanifest/_search',
+		path: '/:base/documentmanifest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/documentmanifest/:id',
+		path: '/:base/documentmanifest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/documentmanifest',
+		path: '/:base/documentmanifest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/documentmanifest/:id',
+		path: '/:base/documentmanifest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/documentmanifest/:id',
+		path: '/:base/documentmanifest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/documentmanifest/documentmanifest.controller.js
+++ b/src/server/profiles/documentmanifest/documentmanifest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentManifest = require(resolveFromVersion(version, 'base/DocumentManifest'));
+		let DocumentManifest = require(resolveFromVersion(base, 'base/DocumentManifest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DocumentManifest, results, {
+				responseUtils.handleBundleReadResponse( res, base, DocumentManifest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentManifest = require(resolveFromVersion(version, 'base/DocumentManifest'));
+		let DocumentManifest = require(resolveFromVersion(base, 'base/DocumentManifest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DocumentManifest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DocumentManifest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentManifest = require(resolveFromVersion(version, 'base/DocumentManifest'));
+		let DocumentManifest = require(resolveFromVersion(base, 'base/DocumentManifest'));
 		// Validate the resource type before creating it
 		if (DocumentManifest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DocumentManifest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DocumentManifest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DocumentManifest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentManifest = require(resolveFromVersion(version, 'base/DocumentManifest'));
+		let DocumentManifest = require(resolveFromVersion(base, 'base/DocumentManifest'));
 		// Validate the resource type before creating it
 		if (DocumentManifest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DocumentManifest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DocumentManifest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DocumentManifest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/documentreference/documentreference.config.js
+++ b/src/server/profiles/documentreference/documentreference.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/documentreference',
+		path: '/:base/documentreference',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/documentreference/_search',
+		path: '/:base/documentreference/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/documentreference/:id',
+		path: '/:base/documentreference/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/documentreference',
+		path: '/:base/documentreference',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/documentreference/:id',
+		path: '/:base/documentreference/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/documentreference/:id',
+		path: '/:base/documentreference/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/documentreference/documentreference.controller.js
+++ b/src/server/profiles/documentreference/documentreference.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentReference = require(resolveFromVersion(version, 'base/DocumentReference'));
+		let DocumentReference = require(resolveFromVersion(base, 'base/DocumentReference'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, DocumentReference, results, {
+				responseUtils.handleBundleReadResponse( res, base, DocumentReference, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentReference = require(resolveFromVersion(version, 'base/DocumentReference'));
+		let DocumentReference = require(resolveFromVersion(base, 'base/DocumentReference'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, DocumentReference, results)
+				responseUtils.handleSingleReadResponse(res, next, base, DocumentReference, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentReference = require(resolveFromVersion(version, 'base/DocumentReference'));
+		let DocumentReference = require(resolveFromVersion(base, 'base/DocumentReference'));
 		// Validate the resource type before creating it
 		if (DocumentReference.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DocumentReference.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, DocumentReference.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, DocumentReference.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let DocumentReference = require(resolveFromVersion(version, 'base/DocumentReference'));
+		let DocumentReference = require(resolveFromVersion(base, 'base/DocumentReference'));
 		// Validate the resource type before creating it
 		if (DocumentReference.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${DocumentReference.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, DocumentReference.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, DocumentReference.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/eligibilityrequest/eligibilityrequest.config.js
+++ b/src/server/profiles/eligibilityrequest/eligibilityrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/eligibilityrequest',
+		path: '/:base/eligibilityrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/eligibilityrequest/_search',
+		path: '/:base/eligibilityrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/eligibilityrequest/:id',
+		path: '/:base/eligibilityrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/eligibilityrequest',
+		path: '/:base/eligibilityrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/eligibilityrequest/:id',
+		path: '/:base/eligibilityrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/eligibilityrequest/:id',
+		path: '/:base/eligibilityrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
+++ b/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityRequest = require(resolveFromVersion(version, 'base/EligibilityRequest'));
+		let EligibilityRequest = require(resolveFromVersion(base, 'base/EligibilityRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EligibilityRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, EligibilityRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityRequest = require(resolveFromVersion(version, 'base/EligibilityRequest'));
+		let EligibilityRequest = require(resolveFromVersion(base, 'base/EligibilityRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EligibilityRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EligibilityRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityRequest = require(resolveFromVersion(version, 'base/EligibilityRequest'));
+		let EligibilityRequest = require(resolveFromVersion(base, 'base/EligibilityRequest'));
 		// Validate the resource type before creating it
 		if (EligibilityRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EligibilityRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EligibilityRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EligibilityRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityRequest = require(resolveFromVersion(version, 'base/EligibilityRequest'));
+		let EligibilityRequest = require(resolveFromVersion(base, 'base/EligibilityRequest'));
 		// Validate the resource type before creating it
 		if (EligibilityRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EligibilityRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EligibilityRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EligibilityRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/eligibilityresponse/eligibilityresponse.config.js
+++ b/src/server/profiles/eligibilityresponse/eligibilityresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/eligibilityresponse',
+		path: '/:base/eligibilityresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/eligibilityresponse/_search',
+		path: '/:base/eligibilityresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/eligibilityresponse/:id',
+		path: '/:base/eligibilityresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/eligibilityresponse',
+		path: '/:base/eligibilityresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/eligibilityresponse/:id',
+		path: '/:base/eligibilityresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/eligibilityresponse/:id',
+		path: '/:base/eligibilityresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
+++ b/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityResponse = require(resolveFromVersion(version, 'base/EligibilityResponse'));
+		let EligibilityResponse = require(resolveFromVersion(base, 'base/EligibilityResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EligibilityResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, EligibilityResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityResponse = require(resolveFromVersion(version, 'base/EligibilityResponse'));
+		let EligibilityResponse = require(resolveFromVersion(base, 'base/EligibilityResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EligibilityResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EligibilityResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityResponse = require(resolveFromVersion(version, 'base/EligibilityResponse'));
+		let EligibilityResponse = require(resolveFromVersion(base, 'base/EligibilityResponse'));
 		// Validate the resource type before creating it
 		if (EligibilityResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EligibilityResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EligibilityResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EligibilityResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EligibilityResponse = require(resolveFromVersion(version, 'base/EligibilityResponse'));
+		let EligibilityResponse = require(resolveFromVersion(base, 'base/EligibilityResponse'));
 		// Validate the resource type before creating it
 		if (EligibilityResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EligibilityResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EligibilityResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EligibilityResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/encounter/encounter.config.js
+++ b/src/server/profiles/encounter/encounter.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/encounter',
+		path: '/:base/encounter',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/encounter/_search',
+		path: '/:base/encounter/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/encounter/:id',
+		path: '/:base/encounter/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/encounter',
+		path: '/:base/encounter',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/encounter/:id',
+		path: '/:base/encounter/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/encounter/:id',
+		path: '/:base/encounter/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/encounter/encounter.controller.js
+++ b/src/server/profiles/encounter/encounter.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Encounter = require(resolveFromVersion(version, 'base/Encounter'));
+		let Encounter = require(resolveFromVersion(base, 'base/Encounter'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Encounter, results, {
+				responseUtils.handleBundleReadResponse( res, base, Encounter, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Encounter = require(resolveFromVersion(version, 'base/Encounter'));
+		let Encounter = require(resolveFromVersion(base, 'base/Encounter'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Encounter, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Encounter, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Encounter = require(resolveFromVersion(version, 'base/Encounter'));
+		let Encounter = require(resolveFromVersion(base, 'base/Encounter'));
 		// Validate the resource type before creating it
 		if (Encounter.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Encounter.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Encounter.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Encounter.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Encounter = require(resolveFromVersion(version, 'base/Encounter'));
+		let Encounter = require(resolveFromVersion(base, 'base/Encounter'));
 		// Validate the resource type before creating it
 		if (Encounter.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Encounter.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Encounter.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Encounter.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/endpoint/endpoint.config.js
+++ b/src/server/profiles/endpoint/endpoint.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/endpoint',
+		path: '/:base/endpoint',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/endpoint/_search',
+		path: '/:base/endpoint/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/endpoint/:id',
+		path: '/:base/endpoint/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/endpoint',
+		path: '/:base/endpoint',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/endpoint/:id',
+		path: '/:base/endpoint/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/endpoint/:id',
+		path: '/:base/endpoint/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/endpoint/endpoint.controller.js
+++ b/src/server/profiles/endpoint/endpoint.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EndPoint = require(resolveFromVersion(version, 'base/EndPoint'));
+		let EndPoint = require(resolveFromVersion(base, 'base/EndPoint'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EndPoint, results, {
+				responseUtils.handleBundleReadResponse( res, base, EndPoint, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EndPoint = require(resolveFromVersion(version, 'base/EndPoint'));
+		let EndPoint = require(resolveFromVersion(base, 'base/EndPoint'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EndPoint, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EndPoint, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EndPoint = require(resolveFromVersion(version, 'base/EndPoint'));
+		let EndPoint = require(resolveFromVersion(base, 'base/EndPoint'));
 		// Validate the resource type before creating it
 		if (EndPoint.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EndPoint.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EndPoint.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EndPoint.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EndPoint = require(resolveFromVersion(version, 'base/EndPoint'));
+		let EndPoint = require(resolveFromVersion(base, 'base/EndPoint'));
 		// Validate the resource type before creating it
 		if (EndPoint.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EndPoint.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EndPoint.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EndPoint.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/enrollmentrequest/enrollmentrequest.config.js
+++ b/src/server/profiles/enrollmentrequest/enrollmentrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/enrollmentrequest',
+		path: '/:base/enrollmentrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/enrollmentrequest/_search',
+		path: '/:base/enrollmentrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/enrollmentrequest/:id',
+		path: '/:base/enrollmentrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/enrollmentrequest',
+		path: '/:base/enrollmentrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/enrollmentrequest/:id',
+		path: '/:base/enrollmentrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/enrollmentrequest/:id',
+		path: '/:base/enrollmentrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
+++ b/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentRequest = require(resolveFromVersion(version, 'base/EnrollmentRequest'));
+		let EnrollmentRequest = require(resolveFromVersion(base, 'base/EnrollmentRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EnrollmentRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, EnrollmentRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentRequest = require(resolveFromVersion(version, 'base/EnrollmentRequest'));
+		let EnrollmentRequest = require(resolveFromVersion(base, 'base/EnrollmentRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EnrollmentRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EnrollmentRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentRequest = require(resolveFromVersion(version, 'base/EnrollmentRequest'));
+		let EnrollmentRequest = require(resolveFromVersion(base, 'base/EnrollmentRequest'));
 		// Validate the resource type before creating it
 		if (EnrollmentRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EnrollmentRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EnrollmentRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EnrollmentRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentRequest = require(resolveFromVersion(version, 'base/EnrollmentRequest'));
+		let EnrollmentRequest = require(resolveFromVersion(base, 'base/EnrollmentRequest'));
 		// Validate the resource type before creating it
 		if (EnrollmentRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EnrollmentRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EnrollmentRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EnrollmentRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/enrollmentresponse/enrollmentresponse.config.js
+++ b/src/server/profiles/enrollmentresponse/enrollmentresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/enrollmentresponse',
+		path: '/:base/enrollmentresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/enrollmentresponse/_search',
+		path: '/:base/enrollmentresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/enrollmentresponse/:id',
+		path: '/:base/enrollmentresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/enrollmentresponse',
+		path: '/:base/enrollmentresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/enrollmentresponse/:id',
+		path: '/:base/enrollmentresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/enrollmentresponse/:id',
+		path: '/:base/enrollmentresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
+++ b/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentResponse = require(resolveFromVersion(version, 'base/EnrollmentResponse'));
+		let EnrollmentResponse = require(resolveFromVersion(base, 'base/EnrollmentResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EnrollmentResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, EnrollmentResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentResponse = require(resolveFromVersion(version, 'base/EnrollmentResponse'));
+		let EnrollmentResponse = require(resolveFromVersion(base, 'base/EnrollmentResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EnrollmentResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EnrollmentResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentResponse = require(resolveFromVersion(version, 'base/EnrollmentResponse'));
+		let EnrollmentResponse = require(resolveFromVersion(base, 'base/EnrollmentResponse'));
 		// Validate the resource type before creating it
 		if (EnrollmentResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EnrollmentResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EnrollmentResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EnrollmentResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EnrollmentResponse = require(resolveFromVersion(version, 'base/EnrollmentResponse'));
+		let EnrollmentResponse = require(resolveFromVersion(base, 'base/EnrollmentResponse'));
 		// Validate the resource type before creating it
 		if (EnrollmentResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EnrollmentResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EnrollmentResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EnrollmentResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/episodeofcare/episodeofcare.config.js
+++ b/src/server/profiles/episodeofcare/episodeofcare.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/episodeofcare',
+		path: '/:base/episodeofcare',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/episodeofcare/_search',
+		path: '/:base/episodeofcare/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/episodeofcare/:id',
+		path: '/:base/episodeofcare/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/episodeofcare',
+		path: '/:base/episodeofcare',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/episodeofcare/:id',
+		path: '/:base/episodeofcare/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/episodeofcare/:id',
+		path: '/:base/episodeofcare/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/episodeofcare/episodeofcare.controller.js
+++ b/src/server/profiles/episodeofcare/episodeofcare.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EpisodeOfCare = require(resolveFromVersion(version, 'base/EpisodeOfCare'));
+		let EpisodeOfCare = require(resolveFromVersion(base, 'base/EpisodeOfCare'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, EpisodeOfCare, results, {
+				responseUtils.handleBundleReadResponse( res, base, EpisodeOfCare, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let EpisodeOfCare = require(resolveFromVersion(version, 'base/EpisodeOfCare'));
+		let EpisodeOfCare = require(resolveFromVersion(base, 'base/EpisodeOfCare'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, EpisodeOfCare, results)
+				responseUtils.handleSingleReadResponse(res, next, base, EpisodeOfCare, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EpisodeOfCare = require(resolveFromVersion(version, 'base/EpisodeOfCare'));
+		let EpisodeOfCare = require(resolveFromVersion(base, 'base/EpisodeOfCare'));
 		// Validate the resource type before creating it
 		if (EpisodeOfCare.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EpisodeOfCare.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, EpisodeOfCare.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, EpisodeOfCare.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let EpisodeOfCare = require(resolveFromVersion(version, 'base/EpisodeOfCare'));
+		let EpisodeOfCare = require(resolveFromVersion(base, 'base/EpisodeOfCare'));
 		// Validate the resource type before creating it
 		if (EpisodeOfCare.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${EpisodeOfCare.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, EpisodeOfCare.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, EpisodeOfCare.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/expansionprofile/expansionprofile.config.js
+++ b/src/server/profiles/expansionprofile/expansionprofile.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/expansionprofile',
+		path: '/:base/expansionprofile',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/expansionprofile/_search',
+		path: '/:base/expansionprofile/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/expansionprofile/:id',
+		path: '/:base/expansionprofile/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/expansionprofile',
+		path: '/:base/expansionprofile',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/expansionprofile/:id',
+		path: '/:base/expansionprofile/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/expansionprofile/:id',
+		path: '/:base/expansionprofile/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/expansionprofile/expansionprofile.controller.js
+++ b/src/server/profiles/expansionprofile/expansionprofile.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ExpansionProfile = require(resolveFromVersion(version, 'base/ExpansionProfile'));
+		let ExpansionProfile = require(resolveFromVersion(base, 'base/ExpansionProfile'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ExpansionProfile, results, {
+				responseUtils.handleBundleReadResponse( res, base, ExpansionProfile, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ExpansionProfile = require(resolveFromVersion(version, 'base/ExpansionProfile'));
+		let ExpansionProfile = require(resolveFromVersion(base, 'base/ExpansionProfile'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ExpansionProfile, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ExpansionProfile, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ExpansionProfile = require(resolveFromVersion(version, 'base/ExpansionProfile'));
+		let ExpansionProfile = require(resolveFromVersion(base, 'base/ExpansionProfile'));
 		// Validate the resource type before creating it
 		if (ExpansionProfile.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ExpansionProfile.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ExpansionProfile.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ExpansionProfile.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ExpansionProfile = require(resolveFromVersion(version, 'base/ExpansionProfile'));
+		let ExpansionProfile = require(resolveFromVersion(base, 'base/ExpansionProfile'));
 		// Validate the resource type before creating it
 		if (ExpansionProfile.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ExpansionProfile.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ExpansionProfile.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ExpansionProfile.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/explanationofbenefit/explanationofbenefit.config.js
+++ b/src/server/profiles/explanationofbenefit/explanationofbenefit.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/explanationofbenefit',
+		path: '/:base/explanationofbenefit',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/explanationofbenefit/_search',
+		path: '/:base/explanationofbenefit/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/explanationofbenefit/:id',
+		path: '/:base/explanationofbenefit/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/explanationofbenefit',
+		path: '/:base/explanationofbenefit',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/explanationofbenefit/:id',
+		path: '/:base/explanationofbenefit/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/explanationofbenefit/:id',
+		path: '/:base/explanationofbenefit/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
+++ b/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ExplanationOfBenefit = require(resolveFromVersion(version, 'base/ExplanationOfBenefit'));
+		let ExplanationOfBenefit = require(resolveFromVersion(base, 'base/ExplanationOfBenefit'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ExplanationOfBenefit, results, {
+				responseUtils.handleBundleReadResponse( res, base, ExplanationOfBenefit, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ExplanationOfBenefit = require(resolveFromVersion(version, 'base/ExplanationOfBenefit'));
+		let ExplanationOfBenefit = require(resolveFromVersion(base, 'base/ExplanationOfBenefit'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ExplanationOfBenefit, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ExplanationOfBenefit, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ExplanationOfBenefit = require(resolveFromVersion(version, 'base/ExplanationOfBenefit'));
+		let ExplanationOfBenefit = require(resolveFromVersion(base, 'base/ExplanationOfBenefit'));
 		// Validate the resource type before creating it
 		if (ExplanationOfBenefit.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ExplanationOfBenefit.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ExplanationOfBenefit.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ExplanationOfBenefit.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ExplanationOfBenefit = require(resolveFromVersion(version, 'base/ExplanationOfBenefit'));
+		let ExplanationOfBenefit = require(resolveFromVersion(base, 'base/ExplanationOfBenefit'));
 		// Validate the resource type before creating it
 		if (ExplanationOfBenefit.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ExplanationOfBenefit.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ExplanationOfBenefit.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ExplanationOfBenefit.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/familymemberhistory/familymemberhistory.config.js
+++ b/src/server/profiles/familymemberhistory/familymemberhistory.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/familymemberhistory',
+		path: '/:base/familymemberhistory',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/familymemberhistory/_search',
+		path: '/:base/familymemberhistory/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/familymemberhistory/:id',
+		path: '/:base/familymemberhistory/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/familymemberhistory',
+		path: '/:base/familymemberhistory',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/familymemberhistory/:id',
+		path: '/:base/familymemberhistory/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/familymemberhistory/:id',
+		path: '/:base/familymemberhistory/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
+++ b/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let FamilyMemberHistory = require(resolveFromVersion(version, 'base/FamilyMemberHistory'));
+		let FamilyMemberHistory = require(resolveFromVersion(base, 'base/FamilyMemberHistory'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, FamilyMemberHistory, results, {
+				responseUtils.handleBundleReadResponse( res, base, FamilyMemberHistory, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let FamilyMemberHistory = require(resolveFromVersion(version, 'base/FamilyMemberHistory'));
+		let FamilyMemberHistory = require(resolveFromVersion(base, 'base/FamilyMemberHistory'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, FamilyMemberHistory, results)
+				responseUtils.handleSingleReadResponse(res, next, base, FamilyMemberHistory, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let FamilyMemberHistory = require(resolveFromVersion(version, 'base/FamilyMemberHistory'));
+		let FamilyMemberHistory = require(resolveFromVersion(base, 'base/FamilyMemberHistory'));
 		// Validate the resource type before creating it
 		if (FamilyMemberHistory.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${FamilyMemberHistory.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, FamilyMemberHistory.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, FamilyMemberHistory.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let FamilyMemberHistory = require(resolveFromVersion(version, 'base/FamilyMemberHistory'));
+		let FamilyMemberHistory = require(resolveFromVersion(base, 'base/FamilyMemberHistory'));
 		// Validate the resource type before creating it
 		if (FamilyMemberHistory.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${FamilyMemberHistory.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, FamilyMemberHistory.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, FamilyMemberHistory.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/flag/flag.config.js
+++ b/src/server/profiles/flag/flag.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/flag',
+		path: '/:base/flag',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/flag/_search',
+		path: '/:base/flag/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/flag/:id',
+		path: '/:base/flag/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/flag',
+		path: '/:base/flag',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/flag/:id',
+		path: '/:base/flag/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/flag/:id',
+		path: '/:base/flag/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/flag/flag.controller.js
+++ b/src/server/profiles/flag/flag.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Flag = require(resolveFromVersion(version, 'base/Flag'));
+		let Flag = require(resolveFromVersion(base, 'base/Flag'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Flag, results, {
+				responseUtils.handleBundleReadResponse( res, base, Flag, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Flag = require(resolveFromVersion(version, 'base/Flag'));
+		let Flag = require(resolveFromVersion(base, 'base/Flag'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Flag, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Flag, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Flag = require(resolveFromVersion(version, 'base/Flag'));
+		let Flag = require(resolveFromVersion(base, 'base/Flag'));
 		// Validate the resource type before creating it
 		if (Flag.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Flag.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Flag.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Flag.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Flag = require(resolveFromVersion(version, 'base/Flag'));
+		let Flag = require(resolveFromVersion(base, 'base/Flag'));
 		// Validate the resource type before creating it
 		if (Flag.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Flag.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Flag.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Flag.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/goal/goal.config.js
+++ b/src/server/profiles/goal/goal.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/goal',
+		path: '/:base/goal',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/goal/_search',
+		path: '/:base/goal/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/goal/:id',
+		path: '/:base/goal/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/goal',
+		path: '/:base/goal',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/goal/:id',
+		path: '/:base/goal/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/goal/:id',
+		path: '/:base/goal/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/goal/goal.controller.js
+++ b/src/server/profiles/goal/goal.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific goal
-		let Goal = require(resolveFromVersion(version, 'uscore/Goal'));
+		let Goal = require(resolveFromVersion(base, 'uscore/Goal'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Goal, results, {
+				responseUtils.handleBundleReadResponse( res, base, Goal, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific goal
-		let Goal = require(resolveFromVersion(version, 'uscore/Goal'));
+		let Goal = require(resolveFromVersion(base, 'uscore/Goal'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Goal, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Goal, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific goal
-		let Goal = require(resolveFromVersion(version, 'uscore/Goal'));
+		let Goal = require(resolveFromVersion(base, 'uscore/Goal'));
 		// Validate the resource type before creating it
 		if (Goal.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Goal.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new goal resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Goal.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Goal.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific goal
-		let Goal = require(resolveFromVersion(version, 'uscore/Goal'));
+		let Goal = require(resolveFromVersion(base, 'uscore/Goal'));
 		// Validate the resource type before creating it
 		if (Goal.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Goal.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new goal resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Goal.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Goal.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/graphdefinition/graphdefinition.config.js
+++ b/src/server/profiles/graphdefinition/graphdefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/graphdefinition',
+		path: '/:base/graphdefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/graphdefinition/_search',
+		path: '/:base/graphdefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/graphdefinition/:id',
+		path: '/:base/graphdefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/graphdefinition',
+		path: '/:base/graphdefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/graphdefinition/:id',
+		path: '/:base/graphdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/graphdefinition/:id',
+		path: '/:base/graphdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/graphdefinition/graphdefinition.controller.js
+++ b/src/server/profiles/graphdefinition/graphdefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let GraphDefinition = require(resolveFromVersion(version, 'base/GraphDefinition'));
+		let GraphDefinition = require(resolveFromVersion(base, 'base/GraphDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, GraphDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, GraphDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let GraphDefinition = require(resolveFromVersion(version, 'base/GraphDefinition'));
+		let GraphDefinition = require(resolveFromVersion(base, 'base/GraphDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, GraphDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, GraphDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let GraphDefinition = require(resolveFromVersion(version, 'base/GraphDefinition'));
+		let GraphDefinition = require(resolveFromVersion(base, 'base/GraphDefinition'));
 		// Validate the resource type before creating it
 		if (GraphDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${GraphDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, GraphDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, GraphDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let GraphDefinition = require(resolveFromVersion(version, 'base/GraphDefinition'));
+		let GraphDefinition = require(resolveFromVersion(base, 'base/GraphDefinition'));
 		// Validate the resource type before creating it
 		if (GraphDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${GraphDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, GraphDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, GraphDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/group/group.config.js
+++ b/src/server/profiles/group/group.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/group',
+		path: '/:base/group',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/group/_search',
+		path: '/:base/group/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/group/:id',
+		path: '/:base/group/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/group',
+		path: '/:base/group',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/group/:id',
+		path: '/:base/group/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/group/:id',
+		path: '/:base/group/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/group/group.controller.js
+++ b/src/server/profiles/group/group.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Group = require(resolveFromVersion(version, 'base/Group'));
+		let Group = require(resolveFromVersion(base, 'base/Group'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Group, results, {
+				responseUtils.handleBundleReadResponse( res, base, Group, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Group = require(resolveFromVersion(version, 'base/Group'));
+		let Group = require(resolveFromVersion(base, 'base/Group'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Group, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Group, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Group = require(resolveFromVersion(version, 'base/Group'));
+		let Group = require(resolveFromVersion(base, 'base/Group'));
 		// Validate the resource type before creating it
 		if (Group.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Group.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Group.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Group.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Group = require(resolveFromVersion(version, 'base/Group'));
+		let Group = require(resolveFromVersion(base, 'base/Group'));
 		// Validate the resource type before creating it
 		if (Group.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Group.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Group.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Group.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/guidanceresponse/guidanceresponse.config.js
+++ b/src/server/profiles/guidanceresponse/guidanceresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/guidanceresponse',
+		path: '/:base/guidanceresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/guidanceresponse/_search',
+		path: '/:base/guidanceresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/guidanceresponse/:id',
+		path: '/:base/guidanceresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/guidanceresponse',
+		path: '/:base/guidanceresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/guidanceresponse/:id',
+		path: '/:base/guidanceresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/guidanceresponse/:id',
+		path: '/:base/guidanceresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
+++ b/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let GuidanceResponse = require(resolveFromVersion(version, 'base/GuidanceResponse'));
+		let GuidanceResponse = require(resolveFromVersion(base, 'base/GuidanceResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, GuidanceResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, GuidanceResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let GuidanceResponse = require(resolveFromVersion(version, 'base/GuidanceResponse'));
+		let GuidanceResponse = require(resolveFromVersion(base, 'base/GuidanceResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, GuidanceResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, GuidanceResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let GuidanceResponse = require(resolveFromVersion(version, 'base/GuidanceResponse'));
+		let GuidanceResponse = require(resolveFromVersion(base, 'base/GuidanceResponse'));
 		// Validate the resource type before creating it
 		if (GuidanceResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${GuidanceResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, GuidanceResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, GuidanceResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let GuidanceResponse = require(resolveFromVersion(version, 'base/GuidanceResponse'));
+		let GuidanceResponse = require(resolveFromVersion(base, 'base/GuidanceResponse'));
 		// Validate the resource type before creating it
 		if (GuidanceResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${GuidanceResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, GuidanceResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, GuidanceResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/healthcareservice/healthcareservice.config.js
+++ b/src/server/profiles/healthcareservice/healthcareservice.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/healthcareservice',
+		path: '/:base/healthcareservice',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/healthcareservice/_search',
+		path: '/:base/healthcareservice/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/healthcareservice/:id',
+		path: '/:base/healthcareservice/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/healthcareservice',
+		path: '/:base/healthcareservice',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/healthcareservice/:id',
+		path: '/:base/healthcareservice/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/healthcareservice/:id',
+		path: '/:base/healthcareservice/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/healthcareservice/healthcareservice.controller.js
+++ b/src/server/profiles/healthcareservice/healthcareservice.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let HealthcareService = require(resolveFromVersion(version, 'base/HealthcareService'));
+		let HealthcareService = require(resolveFromVersion(base, 'base/HealthcareService'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, HealthcareService, results, {
+				responseUtils.handleBundleReadResponse( res, base, HealthcareService, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let HealthcareService = require(resolveFromVersion(version, 'base/HealthcareService'));
+		let HealthcareService = require(resolveFromVersion(base, 'base/HealthcareService'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, HealthcareService, results)
+				responseUtils.handleSingleReadResponse(res, next, base, HealthcareService, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let HealthcareService = require(resolveFromVersion(version, 'base/HealthcareService'));
+		let HealthcareService = require(resolveFromVersion(base, 'base/HealthcareService'));
 		// Validate the resource type before creating it
 		if (HealthcareService.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${HealthcareService.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, HealthcareService.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, HealthcareService.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let HealthcareService = require(resolveFromVersion(version, 'base/HealthcareService'));
+		let HealthcareService = require(resolveFromVersion(base, 'base/HealthcareService'));
 		// Validate the resource type before creating it
 		if (HealthcareService.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${HealthcareService.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, HealthcareService.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, HealthcareService.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/imagingmanifest/imagingmanifest.config.js
+++ b/src/server/profiles/imagingmanifest/imagingmanifest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/imagingmanifest',
+		path: '/:base/imagingmanifest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/imagingmanifest/_search',
+		path: '/:base/imagingmanifest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/imagingmanifest/:id',
+		path: '/:base/imagingmanifest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/imagingmanifest',
+		path: '/:base/imagingmanifest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/imagingmanifest/:id',
+		path: '/:base/imagingmanifest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/imagingmanifest/:id',
+		path: '/:base/imagingmanifest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
+++ b/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingManifest = require(resolveFromVersion(version, 'base/ImagingManifest'));
+		let ImagingManifest = require(resolveFromVersion(base, 'base/ImagingManifest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ImagingManifest, results, {
+				responseUtils.handleBundleReadResponse( res, base, ImagingManifest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingManifest = require(resolveFromVersion(version, 'base/ImagingManifest'));
+		let ImagingManifest = require(resolveFromVersion(base, 'base/ImagingManifest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ImagingManifest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ImagingManifest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingManifest = require(resolveFromVersion(version, 'base/ImagingManifest'));
+		let ImagingManifest = require(resolveFromVersion(base, 'base/ImagingManifest'));
 		// Validate the resource type before creating it
 		if (ImagingManifest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImagingManifest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ImagingManifest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ImagingManifest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingManifest = require(resolveFromVersion(version, 'base/ImagingManifest'));
+		let ImagingManifest = require(resolveFromVersion(base, 'base/ImagingManifest'));
 		// Validate the resource type before creating it
 		if (ImagingManifest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImagingManifest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ImagingManifest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ImagingManifest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/imagingstudy/imagingstudy.config.js
+++ b/src/server/profiles/imagingstudy/imagingstudy.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/imagingstudy',
+		path: '/:base/imagingstudy',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/imagingstudy/_search',
+		path: '/:base/imagingstudy/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/imagingstudy/:id',
+		path: '/:base/imagingstudy/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/imagingstudy',
+		path: '/:base/imagingstudy',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/imagingstudy/:id',
+		path: '/:base/imagingstudy/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/imagingstudy/:id',
+		path: '/:base/imagingstudy/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/imagingstudy/imagingstudy.controller.js
+++ b/src/server/profiles/imagingstudy/imagingstudy.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingStudy = require(resolveFromVersion(version, 'base/ImagingStudy'));
+		let ImagingStudy = require(resolveFromVersion(base, 'base/ImagingStudy'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ImagingStudy, results, {
+				responseUtils.handleBundleReadResponse( res, base, ImagingStudy, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingStudy = require(resolveFromVersion(version, 'base/ImagingStudy'));
+		let ImagingStudy = require(resolveFromVersion(base, 'base/ImagingStudy'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ImagingStudy, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ImagingStudy, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingStudy = require(resolveFromVersion(version, 'base/ImagingStudy'));
+		let ImagingStudy = require(resolveFromVersion(base, 'base/ImagingStudy'));
 		// Validate the resource type before creating it
 		if (ImagingStudy.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImagingStudy.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ImagingStudy.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ImagingStudy.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImagingStudy = require(resolveFromVersion(version, 'base/ImagingStudy'));
+		let ImagingStudy = require(resolveFromVersion(base, 'base/ImagingStudy'));
 		// Validate the resource type before creating it
 		if (ImagingStudy.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImagingStudy.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ImagingStudy.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ImagingStudy.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/immunization/immunization.config.js
+++ b/src/server/profiles/immunization/immunization.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/immunization',
+		path: '/:base/immunization',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/immunization/_search',
+		path: '/:base/immunization/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/immunization/:id',
+		path: '/:base/immunization/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/immunization',
+		path: '/:base/immunization',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/immunization/:id',
+		path: '/:base/immunization/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/immunization/:id',
+		path: '/:base/immunization/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/immunization/immunization.controller.js
+++ b/src/server/profiles/immunization/immunization.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific immunization
-		let Immunization = require(resolveFromVersion(version, 'uscore/Immunization'));
+		let Immunization = require(resolveFromVersion(base, 'uscore/Immunization'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Immunization, results, {
+				responseUtils.handleBundleReadResponse( res, base, Immunization, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific immunization
-		let Immunization = require(resolveFromVersion(version, 'uscore/Immunization'));
+		let Immunization = require(resolveFromVersion(base, 'uscore/Immunization'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Immunization, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Immunization, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific immunization
-		let Immunization = require(resolveFromVersion(version, 'uscore/Immunization'));
+		let Immunization = require(resolveFromVersion(base, 'uscore/Immunization'));
 		// Validate the resource type before creating it
 		if (Immunization.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Immunization.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new immunization resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Immunization.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Immunization.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific immunization
-		let Immunization = require(resolveFromVersion(version, 'uscore/Immunization'));
+		let Immunization = require(resolveFromVersion(base, 'uscore/Immunization'));
 		// Validate the resource type before creating it
 		if (Immunization.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Immunization.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new immunization resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Immunization.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Immunization.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/immunizationrecommendation/immunizationrecommendation.config.js
+++ b/src/server/profiles/immunizationrecommendation/immunizationrecommendation.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/immunizationrecommendation',
+		path: '/:base/immunizationrecommendation',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/immunizationrecommendation/_search',
+		path: '/:base/immunizationrecommendation/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/immunizationrecommendation/:id',
+		path: '/:base/immunizationrecommendation/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/immunizationrecommendation',
+		path: '/:base/immunizationrecommendation',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/immunizationrecommendation/:id',
+		path: '/:base/immunizationrecommendation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/immunizationrecommendation/:id',
+		path: '/:base/immunizationrecommendation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
+++ b/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImmunizationRecommendation = require(resolveFromVersion(version, 'base/ImmunizationRecommendation'));
+		let ImmunizationRecommendation = require(resolveFromVersion(base, 'base/ImmunizationRecommendation'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ImmunizationRecommendation, results, {
+				responseUtils.handleBundleReadResponse( res, base, ImmunizationRecommendation, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImmunizationRecommendation = require(resolveFromVersion(version, 'base/ImmunizationRecommendation'));
+		let ImmunizationRecommendation = require(resolveFromVersion(base, 'base/ImmunizationRecommendation'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ImmunizationRecommendation, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ImmunizationRecommendation, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImmunizationRecommendation = require(resolveFromVersion(version, 'base/ImmunizationRecommendation'));
+		let ImmunizationRecommendation = require(resolveFromVersion(base, 'base/ImmunizationRecommendation'));
 		// Validate the resource type before creating it
 		if (ImmunizationRecommendation.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImmunizationRecommendation.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ImmunizationRecommendation.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ImmunizationRecommendation.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImmunizationRecommendation = require(resolveFromVersion(version, 'base/ImmunizationRecommendation'));
+		let ImmunizationRecommendation = require(resolveFromVersion(base, 'base/ImmunizationRecommendation'));
 		// Validate the resource type before creating it
 		if (ImmunizationRecommendation.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImmunizationRecommendation.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ImmunizationRecommendation.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ImmunizationRecommendation.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/implementationguide/implementationguide.config.js
+++ b/src/server/profiles/implementationguide/implementationguide.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/implementationguide',
+		path: '/:base/implementationguide',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/implementationguide/_search',
+		path: '/:base/implementationguide/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/implementationguide/:id',
+		path: '/:base/implementationguide/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/implementationguide',
+		path: '/:base/implementationguide',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/implementationguide/:id',
+		path: '/:base/implementationguide/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/implementationguide/:id',
+		path: '/:base/implementationguide/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/implementationguide/implementationguide.controller.js
+++ b/src/server/profiles/implementationguide/implementationguide.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImplementationGuide = require(resolveFromVersion(version, 'base/ImplementationGuide'));
+		let ImplementationGuide = require(resolveFromVersion(base, 'base/ImplementationGuide'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ImplementationGuide, results, {
+				responseUtils.handleBundleReadResponse( res, base, ImplementationGuide, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ImplementationGuide = require(resolveFromVersion(version, 'base/ImplementationGuide'));
+		let ImplementationGuide = require(resolveFromVersion(base, 'base/ImplementationGuide'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ImplementationGuide, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ImplementationGuide, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImplementationGuide = require(resolveFromVersion(version, 'base/ImplementationGuide'));
+		let ImplementationGuide = require(resolveFromVersion(base, 'base/ImplementationGuide'));
 		// Validate the resource type before creating it
 		if (ImplementationGuide.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImplementationGuide.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ImplementationGuide.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ImplementationGuide.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ImplementationGuide = require(resolveFromVersion(version, 'base/ImplementationGuide'));
+		let ImplementationGuide = require(resolveFromVersion(base, 'base/ImplementationGuide'));
 		// Validate the resource type before creating it
 		if (ImplementationGuide.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ImplementationGuide.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ImplementationGuide.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ImplementationGuide.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/library/library.config.js
+++ b/src/server/profiles/library/library.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/library',
+		path: '/:base/library',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/library/_search',
+		path: '/:base/library/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/library/:id',
+		path: '/:base/library/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/library',
+		path: '/:base/library',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/library/:id',
+		path: '/:base/library/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/library/:id',
+		path: '/:base/library/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/library/library.controller.js
+++ b/src/server/profiles/library/library.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Library = require(resolveFromVersion(version, 'base/Library'));
+		let Library = require(resolveFromVersion(base, 'base/Library'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Library, results, {
+				responseUtils.handleBundleReadResponse( res, base, Library, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Library = require(resolveFromVersion(version, 'base/Library'));
+		let Library = require(resolveFromVersion(base, 'base/Library'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Library, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Library, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Library = require(resolveFromVersion(version, 'base/Library'));
+		let Library = require(resolveFromVersion(base, 'base/Library'));
 		// Validate the resource type before creating it
 		if (Library.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Library.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Library.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Library.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Library = require(resolveFromVersion(version, 'base/Library'));
+		let Library = require(resolveFromVersion(base, 'base/Library'));
 		// Validate the resource type before creating it
 		if (Library.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Library.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Library.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Library.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/linkage/linkage.config.js
+++ b/src/server/profiles/linkage/linkage.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/linkage',
+		path: '/:base/linkage',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/linkage/_search',
+		path: '/:base/linkage/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/linkage/:id',
+		path: '/:base/linkage/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/linkage',
+		path: '/:base/linkage',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/linkage/:id',
+		path: '/:base/linkage/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/linkage/:id',
+		path: '/:base/linkage/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/linkage/linkage.controller.js
+++ b/src/server/profiles/linkage/linkage.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Linkage = require(resolveFromVersion(version, 'base/Linkage'));
+		let Linkage = require(resolveFromVersion(base, 'base/Linkage'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Linkage, results, {
+				responseUtils.handleBundleReadResponse( res, base, Linkage, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Linkage = require(resolveFromVersion(version, 'base/Linkage'));
+		let Linkage = require(resolveFromVersion(base, 'base/Linkage'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Linkage, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Linkage, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Linkage = require(resolveFromVersion(version, 'base/Linkage'));
+		let Linkage = require(resolveFromVersion(base, 'base/Linkage'));
 		// Validate the resource type before creating it
 		if (Linkage.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Linkage.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Linkage.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Linkage.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Linkage = require(resolveFromVersion(version, 'base/Linkage'));
+		let Linkage = require(resolveFromVersion(base, 'base/Linkage'));
 		// Validate the resource type before creating it
 		if (Linkage.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Linkage.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Linkage.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Linkage.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/list/list.config.js
+++ b/src/server/profiles/list/list.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/list',
+		path: '/:base/list',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/list/_search',
+		path: '/:base/list/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/list/:id',
+		path: '/:base/list/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/list',
+		path: '/:base/list',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/list/:id',
+		path: '/:base/list/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/list/:id',
+		path: '/:base/list/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/list/list.controller.js
+++ b/src/server/profiles/list/list.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let List = require(resolveFromVersion(version, 'base/List'));
+		let List = require(resolveFromVersion(base, 'base/List'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, List, results, {
+				responseUtils.handleBundleReadResponse( res, base, List, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let List = require(resolveFromVersion(version, 'base/List'));
+		let List = require(resolveFromVersion(base, 'base/List'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, List, results)
+				responseUtils.handleSingleReadResponse(res, next, base, List, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let List = require(resolveFromVersion(version, 'base/List'));
+		let List = require(resolveFromVersion(base, 'base/List'));
 		// Validate the resource type before creating it
 		if (List.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${List.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, List.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, List.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let List = require(resolveFromVersion(version, 'base/List'));
+		let List = require(resolveFromVersion(base, 'base/List'));
 		// Validate the resource type before creating it
 		if (List.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${List.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, List.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, List.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/location/location.config.js
+++ b/src/server/profiles/location/location.config.js
@@ -14,13 +14,13 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/location',
+		path: '/:base/location',
 		corsOptions: {methods: ['GET']},
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
@@ -28,7 +28,7 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/location/_search',
+		path: '/:base/location/_search',
 		corsOptions: {methods: ['POST']},
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
@@ -36,9 +36,9 @@ let routes = [
 	},
 	{
 		type: 'get',
-		path: '/:version/location/:id',
+		path: '/:base/location/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -46,9 +46,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/location',
+		path: '/:base/location',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -57,10 +57,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/location/:id',
+		path: '/:base/location/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -68,10 +68,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/location/:id',
+		path: '/:base/location/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/location/location.controller.js
+++ b/src/server/profiles/location/location.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific location
-		let Location = require(resolveFromVersion(version, 'uscore/Location'));
+		let Location = require(resolveFromVersion(base, 'uscore/Location'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Location, results, {
+				responseUtils.handleBundleReadResponse( res, base, Location, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific location
-		let Location = require(resolveFromVersion(version, 'uscore/Location'));
+		let Location = require(resolveFromVersion(base, 'uscore/Location'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Location, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Location, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific location
-		let Location = require(resolveFromVersion(version, 'uscore/Location'));
+		let Location = require(resolveFromVersion(base, 'uscore/Location'));
 		// Validate the resource type before creating it
 		if (Location.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Location.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new location resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Location.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Location.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific location
-		let Location = require(resolveFromVersion(version, 'uscore/Location'));
+		let Location = require(resolveFromVersion(base, 'uscore/Location'));
 		// Validate the resource type before creating it
 		if (Location.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Location.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new location resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Location.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Location.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/measure/measure.config.js
+++ b/src/server/profiles/measure/measure.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/measure',
+		path: '/:base/measure',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/measure/_search',
+		path: '/:base/measure/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/measure/:id',
+		path: '/:base/measure/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/measure',
+		path: '/:base/measure',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/measure/:id',
+		path: '/:base/measure/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/measure/:id',
+		path: '/:base/measure/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/measure/measure.controller.js
+++ b/src/server/profiles/measure/measure.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Measure = require(resolveFromVersion(version, 'base/Measure'));
+		let Measure = require(resolveFromVersion(base, 'base/Measure'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Measure, results, {
+				responseUtils.handleBundleReadResponse( res, base, Measure, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Measure = require(resolveFromVersion(version, 'base/Measure'));
+		let Measure = require(resolveFromVersion(base, 'base/Measure'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Measure, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Measure, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Measure = require(resolveFromVersion(version, 'base/Measure'));
+		let Measure = require(resolveFromVersion(base, 'base/Measure'));
 		// Validate the resource type before creating it
 		if (Measure.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Measure.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Measure.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Measure.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Measure = require(resolveFromVersion(version, 'base/Measure'));
+		let Measure = require(resolveFromVersion(base, 'base/Measure'));
 		// Validate the resource type before creating it
 		if (Measure.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Measure.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Measure.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Measure.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/measurereport/measurereport.config.js
+++ b/src/server/profiles/measurereport/measurereport.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/measurereport',
+		path: '/:base/measurereport',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/measurereport/_search',
+		path: '/:base/measurereport/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/measurereport/:id',
+		path: '/:base/measurereport/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/measurereport',
+		path: '/:base/measurereport',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/measurereport/:id',
+		path: '/:base/measurereport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/measurereport/:id',
+		path: '/:base/measurereport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/measurereport/measurereport.controller.js
+++ b/src/server/profiles/measurereport/measurereport.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MeasureReport = require(resolveFromVersion(version, 'base/MeasureReport'));
+		let MeasureReport = require(resolveFromVersion(base, 'base/MeasureReport'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MeasureReport, results, {
+				responseUtils.handleBundleReadResponse( res, base, MeasureReport, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MeasureReport = require(resolveFromVersion(version, 'base/MeasureReport'));
+		let MeasureReport = require(resolveFromVersion(base, 'base/MeasureReport'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MeasureReport, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MeasureReport, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MeasureReport = require(resolveFromVersion(version, 'base/MeasureReport'));
+		let MeasureReport = require(resolveFromVersion(base, 'base/MeasureReport'));
 		// Validate the resource type before creating it
 		if (MeasureReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MeasureReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MeasureReport.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MeasureReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MeasureReport = require(resolveFromVersion(version, 'base/MeasureReport'));
+		let MeasureReport = require(resolveFromVersion(base, 'base/MeasureReport'));
 		// Validate the resource type before creating it
 		if (MeasureReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MeasureReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MeasureReport.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MeasureReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/media/media.config.js
+++ b/src/server/profiles/media/media.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/media',
+		path: '/:base/media',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/media/_search',
+		path: '/:base/media/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/media/:id',
+		path: '/:base/media/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/media',
+		path: '/:base/media',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/media/:id',
+		path: '/:base/media/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/media/:id',
+		path: '/:base/media/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/media/media.controller.js
+++ b/src/server/profiles/media/media.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Media = require(resolveFromVersion(version, 'base/Media'));
+		let Media = require(resolveFromVersion(base, 'base/Media'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Media, results, {
+				responseUtils.handleBundleReadResponse( res, base, Media, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Media = require(resolveFromVersion(version, 'base/Media'));
+		let Media = require(resolveFromVersion(base, 'base/Media'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Media, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Media, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Media = require(resolveFromVersion(version, 'base/Media'));
+		let Media = require(resolveFromVersion(base, 'base/Media'));
 		// Validate the resource type before creating it
 		if (Media.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Media.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Media.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Media.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Media = require(resolveFromVersion(version, 'base/Media'));
+		let Media = require(resolveFromVersion(base, 'base/Media'));
 		// Validate the resource type before creating it
 		if (Media.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Media.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Media.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Media.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/medication/medication.config.js
+++ b/src/server/profiles/medication/medication.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/medication',
+		path: '/:base/medication',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/medication/_search',
+		path: '/:base/medication/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/medication/:id',
+		path: '/:base/medication/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/medication',
+		path: '/:base/medication',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/medication/:id',
+		path: '/:base/medication/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/medication/:id',
+		path: '/:base/medication/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/medication/medication.controller.js
+++ b/src/server/profiles/medication/medication.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific medication & bundle
-		let Medication = require(resolveFromVersion(version, 'uscore/Medication'));
+		let Medication = require(resolveFromVersion(base, 'uscore/Medication'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Medication, results, {
+				responseUtils.handleBundleReadResponse( res, base, Medication, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific medication
-		let Medication = require(resolveFromVersion(version, 'uscore/Medication'));
+		let Medication = require(resolveFromVersion(base, 'uscore/Medication'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Medication, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Medication, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific medication
-		let Medication = require(resolveFromVersion(version, 'uscore/Medication'));
+		let Medication = require(resolveFromVersion(base, 'uscore/Medication'));
 		// Validate the resource type before creating it
 		if (Medication.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Medication.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new medication resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Medication.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Medication.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific medication
-		let Medication = require(resolveFromVersion(version, 'uscore/Medication'));
+		let Medication = require(resolveFromVersion(base, 'uscore/Medication'));
 		// Validate the resource type before creating it
 		if (Medication.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Medication.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new medication resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Medication.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Medication.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/medicationadministration/medicationadministration.config.js
+++ b/src/server/profiles/medicationadministration/medicationadministration.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/medicationadministration',
+		path: '/:base/medicationadministration',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationadministration/_search',
+		path: '/:base/medicationadministration/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/medicationadministration/:id',
+		path: '/:base/medicationadministration/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationadministration',
+		path: '/:base/medicationadministration',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/medicationadministration/:id',
+		path: '/:base/medicationadministration/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/medicationadministration/:id',
+		path: '/:base/medicationadministration/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/medicationadministration/medicationadministration.controller.js
+++ b/src/server/profiles/medicationadministration/medicationadministration.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationAdministration = require(resolveFromVersion(version, 'base/MedicationAdministration'));
+		let MedicationAdministration = require(resolveFromVersion(base, 'base/MedicationAdministration'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MedicationAdministration, results, {
+				responseUtils.handleBundleReadResponse( res, base, MedicationAdministration, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationAdministration = require(resolveFromVersion(version, 'base/MedicationAdministration'));
+		let MedicationAdministration = require(resolveFromVersion(base, 'base/MedicationAdministration'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MedicationAdministration, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MedicationAdministration, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationAdministration = require(resolveFromVersion(version, 'base/MedicationAdministration'));
+		let MedicationAdministration = require(resolveFromVersion(base, 'base/MedicationAdministration'));
 		// Validate the resource type before creating it
 		if (MedicationAdministration.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationAdministration.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MedicationAdministration.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MedicationAdministration.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationAdministration = require(resolveFromVersion(version, 'base/MedicationAdministration'));
+		let MedicationAdministration = require(resolveFromVersion(base, 'base/MedicationAdministration'));
 		// Validate the resource type before creating it
 		if (MedicationAdministration.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationAdministration.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MedicationAdministration.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MedicationAdministration.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/medicationdispense/medicationdispense.config.js
+++ b/src/server/profiles/medicationdispense/medicationdispense.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/medicationdispense',
+		path: '/:base/medicationdispense',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationdispense/_search',
+		path: '/:base/medicationdispense/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/medicationdispense/:id',
+		path: '/:base/medicationdispense/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationdispense',
+		path: '/:base/medicationdispense',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/medicationdispense/:id',
+		path: '/:base/medicationdispense/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/medicationdispense/:id',
+		path: '/:base/medicationdispense/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/medicationdispense/medicationdispense.controller.js
+++ b/src/server/profiles/medicationdispense/medicationdispense.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationDispense = require(resolveFromVersion(version, 'base/MedicationDispense'));
+		let MedicationDispense = require(resolveFromVersion(base, 'base/MedicationDispense'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MedicationDispense, results, {
+				responseUtils.handleBundleReadResponse( res, base, MedicationDispense, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationDispense = require(resolveFromVersion(version, 'base/MedicationDispense'));
+		let MedicationDispense = require(resolveFromVersion(base, 'base/MedicationDispense'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MedicationDispense, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MedicationDispense, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationDispense = require(resolveFromVersion(version, 'base/MedicationDispense'));
+		let MedicationDispense = require(resolveFromVersion(base, 'base/MedicationDispense'));
 		// Validate the resource type before creating it
 		if (MedicationDispense.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationDispense.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MedicationDispense.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MedicationDispense.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationDispense = require(resolveFromVersion(version, 'base/MedicationDispense'));
+		let MedicationDispense = require(resolveFromVersion(base, 'base/MedicationDispense'));
 		// Validate the resource type before creating it
 		if (MedicationDispense.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationDispense.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MedicationDispense.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MedicationDispense.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/medicationrequest/medicationrequest.config.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/medicationrequest',
+		path: '/:base/medicationrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationrequest/_search',
+		path: '/:base/medicationrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/medicationrequest/:id',
+		path: '/:base/medicationrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationrequest',
+		path: '/:base/medicationrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/medicationrequest/:id',
+		path: '/:base/medicationrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/medicationrequest/:id',
+		path: '/:base/medicationrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/medicationrequest/medicationrequest.controller.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationRequest = require(resolveFromVersion(version, 'uscore/MedicationRequest'));
+		let MedicationRequest = require(resolveFromVersion(base, 'uscore/MedicationRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MedicationRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, MedicationRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationRequest = require(resolveFromVersion(version, 'uscore/MedicationRequest'));
+		let MedicationRequest = require(resolveFromVersion(base, 'uscore/MedicationRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MedicationRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MedicationRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationRequest = require(resolveFromVersion(version, 'uscore/MedicationRequest'));
+		let MedicationRequest = require(resolveFromVersion(base, 'uscore/MedicationRequest'));
 		// Validate the resource type before creating it
 		if (MedicationRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MedicationRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MedicationRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MedicationRequest = require(resolveFromVersion(version, 'uscore/MedicationRequest'));
+		let MedicationRequest = require(resolveFromVersion(base, 'uscore/MedicationRequest'));
 		// Validate the resource type before creating it
 		if (MedicationRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MedicationRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MedicationRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/medicationstatement/medicationstatement.config.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/medicationstatement',
+		path: '/:base/medicationstatement',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationstatement/_search',
+		path: '/:base/medicationstatement/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/medicationstatement/:id',
+		path: '/:base/medicationstatement/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/medicationstatement',
+		path: '/:base/medicationstatement',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/medicationstatement/:id',
+		path: '/:base/medicationstatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/medicationstatement/:id',
+		path: '/:base/medicationstatement/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/medicationstatement/medicationstatement.controller.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific medicationstatement & bundle
-		let MedicationStatement = require(resolveFromVersion(version, 'uscore/MedicationStatement'));
+		let MedicationStatement = require(resolveFromVersion(base, 'uscore/MedicationStatement'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MedicationStatement, results, {
+				responseUtils.handleBundleReadResponse( res, base, MedicationStatement, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific medicationstatement
-		let MedicationStatement = require(resolveFromVersion(version, 'uscore/MedicationStatement'));
+		let MedicationStatement = require(resolveFromVersion(base, 'uscore/MedicationStatement'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MedicationStatement, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MedicationStatement, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific medication_statement
-		let MedicationStatement = require(resolveFromVersion(version, 'uscore/MedicationStatement'));
+		let MedicationStatement = require(resolveFromVersion(base, 'uscore/MedicationStatement'));
 		// Validate the resource type before creating it
 		if (MedicationStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new medication_statement resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MedicationStatement.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MedicationStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific medication_statement
-		let MedicationStatement = require(resolveFromVersion(version, 'uscore/MedicationStatement'));
+		let MedicationStatement = require(resolveFromVersion(base, 'uscore/MedicationStatement'));
 		// Validate the resource type before creating it
 		if (MedicationStatement.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MedicationStatement.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new medication_statement resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MedicationStatement.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MedicationStatement.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/messagedefinition/messagedefinition.config.js
+++ b/src/server/profiles/messagedefinition/messagedefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/messagedefinition',
+		path: '/:base/messagedefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/messagedefinition/_search',
+		path: '/:base/messagedefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/messagedefinition/:id',
+		path: '/:base/messagedefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/messagedefinition',
+		path: '/:base/messagedefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/messagedefinition/:id',
+		path: '/:base/messagedefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/messagedefinition/:id',
+		path: '/:base/messagedefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/messagedefinition/messagedefinition.controller.js
+++ b/src/server/profiles/messagedefinition/messagedefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MessageDefinition = require(resolveFromVersion(version, 'base/MessageDefinition'));
+		let MessageDefinition = require(resolveFromVersion(base, 'base/MessageDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MessageDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, MessageDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MessageDefinition = require(resolveFromVersion(version, 'base/MessageDefinition'));
+		let MessageDefinition = require(resolveFromVersion(base, 'base/MessageDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MessageDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MessageDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MessageDefinition = require(resolveFromVersion(version, 'base/MessageDefinition'));
+		let MessageDefinition = require(resolveFromVersion(base, 'base/MessageDefinition'));
 		// Validate the resource type before creating it
 		if (MessageDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MessageDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MessageDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MessageDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MessageDefinition = require(resolveFromVersion(version, 'base/MessageDefinition'));
+		let MessageDefinition = require(resolveFromVersion(base, 'base/MessageDefinition'));
 		// Validate the resource type before creating it
 		if (MessageDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MessageDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MessageDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MessageDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/messageheader/messageheader.config.js
+++ b/src/server/profiles/messageheader/messageheader.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/messageheader',
+		path: '/:base/messageheader',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/messageheader/_search',
+		path: '/:base/messageheader/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/messageheader/:id',
+		path: '/:base/messageheader/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/messageheader',
+		path: '/:base/messageheader',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/messageheader/:id',
+		path: '/:base/messageheader/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/messageheader/:id',
+		path: '/:base/messageheader/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/messageheader/messageheader.controller.js
+++ b/src/server/profiles/messageheader/messageheader.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MessageHeader = require(resolveFromVersion(version, 'base/MessageHeader'));
+		let MessageHeader = require(resolveFromVersion(base, 'base/MessageHeader'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, MessageHeader, results, {
+				responseUtils.handleBundleReadResponse( res, base, MessageHeader, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let MessageHeader = require(resolveFromVersion(version, 'base/MessageHeader'));
+		let MessageHeader = require(resolveFromVersion(base, 'base/MessageHeader'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, MessageHeader, results)
+				responseUtils.handleSingleReadResponse(res, next, base, MessageHeader, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MessageHeader = require(resolveFromVersion(version, 'base/MessageHeader'));
+		let MessageHeader = require(resolveFromVersion(base, 'base/MessageHeader'));
 		// Validate the resource type before creating it
 		if (MessageHeader.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MessageHeader.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, MessageHeader.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, MessageHeader.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let MessageHeader = require(resolveFromVersion(version, 'base/MessageHeader'));
+		let MessageHeader = require(resolveFromVersion(base, 'base/MessageHeader'));
 		// Validate the resource type before creating it
 		if (MessageHeader.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${MessageHeader.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, MessageHeader.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, MessageHeader.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/metadata/metadata.config.js
+++ b/src/server/profiles/metadata/metadata.config.js
@@ -1,16 +1,14 @@
+const { route_args } = require('../common.arguments');
 const controller = require('./metadata.controller');
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/metadata',
+		path: '/:base/metadata',
 		corsOptions: {
 			methods: ['GET']
 		},
-		args: [{
-			name: 'version',
-			type: 'string'
-		}],
+		args: [ route_args.BASE ],
 		scopes: [],
 		controller: controller.getCapabilityStatement
 	}

--- a/src/server/profiles/metadata/metadata.controller.js
+++ b/src/server/profiles/metadata/metadata.controller.js
@@ -1,4 +1,3 @@
-const errors = require('../../utils/error.utils');
 const service = require('./metadata.service');
 
 /**

--- a/src/server/profiles/metadata/metadata.controller.js
+++ b/src/server/profiles/metadata/metadata.controller.js
@@ -10,6 +10,6 @@ module.exports.getCapabilityStatement = ({ config, logger }) => {
 		// Use our service to generate the capability statement
 		return service.generateCapabilityStatement(req.sanitized_args, config, logger)
 			.then((statement) => res.status(200).json(statement))
-			.catch((err) => next(errors.internal(err.message, req.params.version)));
+			.catch((err) => next(err));
 	};
 };

--- a/src/server/profiles/metadata/metadata.service.js
+++ b/src/server/profiles/metadata/metadata.service.js
@@ -35,19 +35,19 @@ let mapProfiles = (profiles = {}) => {
 * if the service provided does not have a count method then we cannot
 * generate a complete record
 */
-let filterProfiles = (version) => {
+let filterProfiles = (base) => {
 	return resource => (
 		resource.count
 		&& resource.makeResource
-		&& resource.versions.indexOf(version) > -1
+		&& resource.versions.indexOf(base) > -1
 	);
 };
 
 /**
 * Load the correct statement generators for the right version
 */
-let getStatementGenerators = (version) => {
-	switch (version) {
+let getStatementGenerators = (base) => {
+	switch (base) {
 		case VERSIONS.STU3: return require('./capability.stu3');
 		default: return {};
 	}
@@ -67,14 +67,14 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	let { profiles, security } = config;
 	// Create a context object to pass through to underlying services
 	// we may add more information to this later on
-	let context = { version: args.version };
+	let context = { base: args.base };
 	// Get a list of profiles and their conformance info for this spec version
 	let active_profiles = profile_conformance_documents
 		.map(mapProfiles(profiles))
-		.filter(filterProfiles(context.version));
+		.filter(filterProfiles(args.base));
 
 	// Get the necessary functions to generate statements
-	let { makeStatement, securityStatement } = getStatementGenerators(context.version);
+	let { makeStatement, securityStatement } = getStatementGenerators(args.base);
 
 	// If we do not have these functions, we cannot generate a new statement
 	if (!makeStatement || !securityStatement) {

--- a/src/server/profiles/namingsystem/namingsystem.config.js
+++ b/src/server/profiles/namingsystem/namingsystem.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/namingsystem',
+		path: '/:base/namingsystem',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/namingsystem/_search',
+		path: '/:base/namingsystem/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/namingsystem/:id',
+		path: '/:base/namingsystem/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/namingsystem',
+		path: '/:base/namingsystem',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/namingsystem/:id',
+		path: '/:base/namingsystem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/namingsystem/:id',
+		path: '/:base/namingsystem/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/namingsystem/namingsystem.controller.js
+++ b/src/server/profiles/namingsystem/namingsystem.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let NamingSystem = require(resolveFromVersion(version, 'base/NamingSystem'));
+		let NamingSystem = require(resolveFromVersion(base, 'base/NamingSystem'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, NamingSystem, results, {
+				responseUtils.handleBundleReadResponse( res, base, NamingSystem, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let NamingSystem = require(resolveFromVersion(version, 'base/NamingSystem'));
+		let NamingSystem = require(resolveFromVersion(base, 'base/NamingSystem'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, NamingSystem, results)
+				responseUtils.handleSingleReadResponse(res, next, base, NamingSystem, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let NamingSystem = require(resolveFromVersion(version, 'base/NamingSystem'));
+		let NamingSystem = require(resolveFromVersion(base, 'base/NamingSystem'));
 		// Validate the resource type before creating it
 		if (NamingSystem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${NamingSystem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, NamingSystem.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, NamingSystem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let NamingSystem = require(resolveFromVersion(version, 'base/NamingSystem'));
+		let NamingSystem = require(resolveFromVersion(base, 'base/NamingSystem'));
 		// Validate the resource type before creating it
 		if (NamingSystem.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${NamingSystem.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, NamingSystem.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, NamingSystem.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/nutritionorder/nutritionorder.config.js
+++ b/src/server/profiles/nutritionorder/nutritionorder.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/nutritionorder',
+		path: '/:base/nutritionorder',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/nutritionorder/_search',
+		path: '/:base/nutritionorder/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/nutritionorder/:id',
+		path: '/:base/nutritionorder/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/nutritionorder',
+		path: '/:base/nutritionorder',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/nutritionorder/:id',
+		path: '/:base/nutritionorder/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/nutritionorder/:id',
+		path: '/:base/nutritionorder/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/nutritionorder/nutritionorder.controller.js
+++ b/src/server/profiles/nutritionorder/nutritionorder.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let NutritionOrder = require(resolveFromVersion(version, 'base/NutritionOrder'));
+		let NutritionOrder = require(resolveFromVersion(base, 'base/NutritionOrder'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, NutritionOrder, results, {
+				responseUtils.handleBundleReadResponse( res, base, NutritionOrder, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let NutritionOrder = require(resolveFromVersion(version, 'base/NutritionOrder'));
+		let NutritionOrder = require(resolveFromVersion(base, 'base/NutritionOrder'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, NutritionOrder, results)
+				responseUtils.handleSingleReadResponse(res, next, base, NutritionOrder, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let NutritionOrder = require(resolveFromVersion(version, 'base/NutritionOrder'));
+		let NutritionOrder = require(resolveFromVersion(base, 'base/NutritionOrder'));
 		// Validate the resource type before creating it
 		if (NutritionOrder.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${NutritionOrder.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, NutritionOrder.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, NutritionOrder.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let NutritionOrder = require(resolveFromVersion(version, 'base/NutritionOrder'));
+		let NutritionOrder = require(resolveFromVersion(base, 'base/NutritionOrder'));
 		// Validate the resource type before creating it
 		if (NutritionOrder.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${NutritionOrder.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, NutritionOrder.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, NutritionOrder.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/observation/observation.config.js
+++ b/src/server/profiles/observation/observation.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/observation',
+		path: '/:base/observation',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/observation/_search',
+		path: '/:base/observation/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/observation/:id',
+		path: '/:base/observation/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/observation',
+		path: '/:base/observation',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/observation/:id',
+		path: '/:base/observation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/observation/:id',
+		path: '/:base/observation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/operationdefinition/operationdefinition.config.js
+++ b/src/server/profiles/operationdefinition/operationdefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/operationdefinition',
+		path: '/:base/operationdefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/operationdefinition/_search',
+		path: '/:base/operationdefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/operationdefinition/:id',
+		path: '/:base/operationdefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/operationdefinition',
+		path: '/:base/operationdefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/operationdefinition/:id',
+		path: '/:base/operationdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/operationdefinition/:id',
+		path: '/:base/operationdefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/operationdefinition/operationdefinition.controller.js
+++ b/src/server/profiles/operationdefinition/operationdefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let OperationDefinition = require(resolveFromVersion(version, 'base/OperationDefinition'));
+		let OperationDefinition = require(resolveFromVersion(base, 'base/OperationDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, OperationDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, OperationDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let OperationDefinition = require(resolveFromVersion(version, 'base/OperationDefinition'));
+		let OperationDefinition = require(resolveFromVersion(base, 'base/OperationDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, OperationDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, OperationDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let OperationDefinition = require(resolveFromVersion(version, 'base/OperationDefinition'));
+		let OperationDefinition = require(resolveFromVersion(base, 'base/OperationDefinition'));
 		// Validate the resource type before creating it
 		if (OperationDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${OperationDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, OperationDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, OperationDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let OperationDefinition = require(resolveFromVersion(version, 'base/OperationDefinition'));
+		let OperationDefinition = require(resolveFromVersion(base, 'base/OperationDefinition'));
 		// Validate the resource type before creating it
 		if (OperationDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${OperationDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, OperationDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, OperationDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/organization/organization.config.js
+++ b/src/server/profiles/organization/organization.config.js
@@ -14,13 +14,13 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/organization',
+		path: '/:base/organization',
 		corsOptions: {methods: ['GET']},
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
@@ -28,7 +28,7 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/organization/_search',
+		path: '/:base/organization/_search',
 		corsOptions: {methods: ['POST']},
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
@@ -36,9 +36,9 @@ let routes = [
 	},
 	{
 		type: 'get',
-		path: '/:version/organization/:id',
+		path: '/:base/organization/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -46,9 +46,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/organization',
+		path: '/:base/organization',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -57,10 +57,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/organization/:id',
+		path: '/:base/organization/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -68,10 +68,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/organization/:id',
+		path: '/:base/organization/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/organization/organization.controller.js
+++ b/src/server/profiles/organization/organization.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific organization & bundle
-		let Organization = require(resolveFromVersion(version, 'uscore/Organization'));
+		let Organization = require(resolveFromVersion(base, 'uscore/Organization'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Organization, results, {
+				responseUtils.handleBundleReadResponse( res, base, Organization, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific organization
-		let Organization = require(resolveFromVersion(version, 'uscore/Organization'));
+		let Organization = require(resolveFromVersion(base, 'uscore/Organization'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Organization, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Organization, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific organization
-		let Organization = require(resolveFromVersion(version, 'uscore/Organization'));
+		let Organization = require(resolveFromVersion(base, 'uscore/Organization'));
 		// Validate the resource type before creating it
 		if (Organization.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Organization.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new organization resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Organization.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Organization.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific organization
-		let Organization = require(resolveFromVersion(version, 'uscore/Organization'));
+		let Organization = require(resolveFromVersion(base, 'uscore/Organization'));
 		// Validate the resource type before creating it
 		if (Organization.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Organization.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new organization resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Organization.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Organization.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/patient/patient.config.js
+++ b/src/server/profiles/patient/patient.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/patient',
+		path: '/:base/patient',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/patient/_search',
+		path: '/:base/patient/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/patient/:id',
+		path: '/:base/patient/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/patient',
+		path: '/:base/patient',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/patient/:id',
+		path: '/:base/patient/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/patient/:id',
+		path: '/:base/patient/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/paymentnotice/paymentnotice.config.js
+++ b/src/server/profiles/paymentnotice/paymentnotice.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/paymentnotice',
+		path: '/:base/paymentnotice',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/paymentnotice/_search',
+		path: '/:base/paymentnotice/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/paymentnotice/:id',
+		path: '/:base/paymentnotice/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/paymentnotice',
+		path: '/:base/paymentnotice',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/paymentnotice/:id',
+		path: '/:base/paymentnotice/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/paymentnotice/:id',
+		path: '/:base/paymentnotice/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/paymentnotice/paymentnotice.controller.js
+++ b/src/server/profiles/paymentnotice/paymentnotice.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentNotice = require(resolveFromVersion(version, 'base/PaymentNotice'));
+		let PaymentNotice = require(resolveFromVersion(base, 'base/PaymentNotice'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, PaymentNotice, results, {
+				responseUtils.handleBundleReadResponse( res, base, PaymentNotice, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentNotice = require(resolveFromVersion(version, 'base/PaymentNotice'));
+		let PaymentNotice = require(resolveFromVersion(base, 'base/PaymentNotice'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, PaymentNotice, results)
+				responseUtils.handleSingleReadResponse(res, next, base, PaymentNotice, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentNotice = require(resolveFromVersion(version, 'base/PaymentNotice'));
+		let PaymentNotice = require(resolveFromVersion(base, 'base/PaymentNotice'));
 		// Validate the resource type before creating it
 		if (PaymentNotice.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PaymentNotice.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, PaymentNotice.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, PaymentNotice.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentNotice = require(resolveFromVersion(version, 'base/PaymentNotice'));
+		let PaymentNotice = require(resolveFromVersion(base, 'base/PaymentNotice'));
 		// Validate the resource type before creating it
 		if (PaymentNotice.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PaymentNotice.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, PaymentNotice.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, PaymentNotice.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/paymentreconciliation/paymentreconciliation.config.js
+++ b/src/server/profiles/paymentreconciliation/paymentreconciliation.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/paymentreconciliation',
+		path: '/:base/paymentreconciliation',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/paymentreconciliation/_search',
+		path: '/:base/paymentreconciliation/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/paymentreconciliation/:id',
+		path: '/:base/paymentreconciliation/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/paymentreconciliation',
+		path: '/:base/paymentreconciliation',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/paymentreconciliation/:id',
+		path: '/:base/paymentreconciliation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/paymentreconciliation/:id',
+		path: '/:base/paymentreconciliation/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
+++ b/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentReconciliation = require(resolveFromVersion(version, 'base/PaymentReconciliation'));
+		let PaymentReconciliation = require(resolveFromVersion(base, 'base/PaymentReconciliation'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, PaymentReconciliation, results, {
+				responseUtils.handleBundleReadResponse( res, base, PaymentReconciliation, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentReconciliation = require(resolveFromVersion(version, 'base/PaymentReconciliation'));
+		let PaymentReconciliation = require(resolveFromVersion(base, 'base/PaymentReconciliation'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, PaymentReconciliation, results)
+				responseUtils.handleSingleReadResponse(res, next, base, PaymentReconciliation, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentReconciliation = require(resolveFromVersion(version, 'base/PaymentReconciliation'));
+		let PaymentReconciliation = require(resolveFromVersion(base, 'base/PaymentReconciliation'));
 		// Validate the resource type before creating it
 		if (PaymentReconciliation.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PaymentReconciliation.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, PaymentReconciliation.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, PaymentReconciliation.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PaymentReconciliation = require(resolveFromVersion(version, 'base/PaymentReconciliation'));
+		let PaymentReconciliation = require(resolveFromVersion(base, 'base/PaymentReconciliation'));
 		// Validate the resource type before creating it
 		if (PaymentReconciliation.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PaymentReconciliation.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, PaymentReconciliation.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, PaymentReconciliation.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/person/person.config.js
+++ b/src/server/profiles/person/person.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/person',
+		path: '/:base/person',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/person/_search',
+		path: '/:base/person/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/person/:id',
+		path: '/:base/person/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/person',
+		path: '/:base/person',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/person/:id',
+		path: '/:base/person/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/person/:id',
+		path: '/:base/person/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/person/person.controller.js
+++ b/src/server/profiles/person/person.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Person = require(resolveFromVersion(version, 'base/Person'));
+		let Person = require(resolveFromVersion(base, 'base/Person'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Person, results, {
+				responseUtils.handleBundleReadResponse( res, base, Person, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Person = require(resolveFromVersion(version, 'base/Person'));
+		let Person = require(resolveFromVersion(base, 'base/Person'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Person, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Person, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Person = require(resolveFromVersion(version, 'base/Person'));
+		let Person = require(resolveFromVersion(base, 'base/Person'));
 		// Validate the resource type before creating it
 		if (Person.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Person.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Person.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Person.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Person = require(resolveFromVersion(version, 'base/Person'));
+		let Person = require(resolveFromVersion(base, 'base/Person'));
 		// Validate the resource type before creating it
 		if (Person.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Person.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Person.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Person.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/plandefinition/plandefinition.config.js
+++ b/src/server/profiles/plandefinition/plandefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/plandefinition',
+		path: '/:base/plandefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/plandefinition/_search',
+		path: '/:base/plandefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/plandefinition/:id',
+		path: '/:base/plandefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/plandefinition',
+		path: '/:base/plandefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/plandefinition/:id',
+		path: '/:base/plandefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/plandefinition/:id',
+		path: '/:base/plandefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/plandefinition/plandefinition.controller.js
+++ b/src/server/profiles/plandefinition/plandefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PlanDefinition = require(resolveFromVersion(version, 'base/PlanDefinition'));
+		let PlanDefinition = require(resolveFromVersion(base, 'base/PlanDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, PlanDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, PlanDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PlanDefinition = require(resolveFromVersion(version, 'base/PlanDefinition'));
+		let PlanDefinition = require(resolveFromVersion(base, 'base/PlanDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, PlanDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, PlanDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PlanDefinition = require(resolveFromVersion(version, 'base/PlanDefinition'));
+		let PlanDefinition = require(resolveFromVersion(base, 'base/PlanDefinition'));
 		// Validate the resource type before creating it
 		if (PlanDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PlanDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, PlanDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, PlanDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PlanDefinition = require(resolveFromVersion(version, 'base/PlanDefinition'));
+		let PlanDefinition = require(resolveFromVersion(base, 'base/PlanDefinition'));
 		// Validate the resource type before creating it
 		if (PlanDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PlanDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, PlanDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, PlanDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/practitioner/practitioner.config.js
+++ b/src/server/profiles/practitioner/practitioner.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/practitioner',
+		path: '/:base/practitioner',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/practitioner/_search',
+		path: '/:base/practitioner/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/practitioner/:id',
+		path: '/:base/practitioner/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/practitioner',
+		path: '/:base/practitioner',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/practitioner/:id',
+		path: '/:base/practitioner/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/practitioner/:id',
+		path: '/:base/practitioner/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/practitioner/practitioner.controller.js
+++ b/src/server/profiles/practitioner/practitioner.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific practitioner
-		let Practitioner = require(resolveFromVersion(version, 'uscore/Practitioner'));
+		let Practitioner = require(resolveFromVersion(base, 'uscore/Practitioner'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Practitioner, results, {
+				responseUtils.handleBundleReadResponse( res, base, Practitioner, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific practitioner
-		let Practitioner = require(resolveFromVersion(version, 'uscore/Practitioner'));
+		let Practitioner = require(resolveFromVersion(base, 'uscore/Practitioner'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Practitioner, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Practitioner, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific practitioner
-		let Practitioner = require(resolveFromVersion(version, 'uscore/Practitioner'));
+		let Practitioner = require(resolveFromVersion(base, 'uscore/Practitioner'));
 		// Validate the resource type before creating it
 		if (Practitioner.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Practitioner.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new practitioner resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Practitioner.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Practitioner.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific practitioner
-		let Practitioner = require(resolveFromVersion(version, 'uscore/Practitioner'));
+		let Practitioner = require(resolveFromVersion(base, 'uscore/Practitioner'));
 		// Validate the resource type before creating it
 		if (Practitioner.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Practitioner.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new practitioner resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Practitioner.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Practitioner.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/practitionerrole/practitionerrole.config.js
+++ b/src/server/profiles/practitionerrole/practitionerrole.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/practitionerrole',
+		path: '/:base/practitionerrole',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/practitionerrole/_search',
+		path: '/:base/practitionerrole/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/practitionerrole/:id',
+		path: '/:base/practitionerrole/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/practitionerrole',
+		path: '/:base/practitionerrole',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/practitionerrole/:id',
+		path: '/:base/practitionerrole/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/practitionerrole/:id',
+		path: '/:base/practitionerrole/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/practitionerrole/practitionerrole.controller.js
+++ b/src/server/profiles/practitionerrole/practitionerrole.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PractitionerRole = require(resolveFromVersion(version, 'base/PractitionerRole'));
+		let PractitionerRole = require(resolveFromVersion(base, 'base/PractitionerRole'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, PractitionerRole, results, {
+				responseUtils.handleBundleReadResponse( res, base, PractitionerRole, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let PractitionerRole = require(resolveFromVersion(version, 'base/PractitionerRole'));
+		let PractitionerRole = require(resolveFromVersion(base, 'base/PractitionerRole'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, PractitionerRole, results)
+				responseUtils.handleSingleReadResponse(res, next, base, PractitionerRole, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PractitionerRole = require(resolveFromVersion(version, 'base/PractitionerRole'));
+		let PractitionerRole = require(resolveFromVersion(base, 'base/PractitionerRole'));
 		// Validate the resource type before creating it
 		if (PractitionerRole.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PractitionerRole.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, PractitionerRole.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, PractitionerRole.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let PractitionerRole = require(resolveFromVersion(version, 'base/PractitionerRole'));
+		let PractitionerRole = require(resolveFromVersion(base, 'base/PractitionerRole'));
 		// Validate the resource type before creating it
 		if (PractitionerRole.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${PractitionerRole.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, PractitionerRole.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, PractitionerRole.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/procedure/procedure.config.js
+++ b/src/server/profiles/procedure/procedure.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/procedure',
+		path: '/:base/procedure',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/procedure/_search',
+		path: '/:base/procedure/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/procedure/:id',
+		path: '/:base/procedure/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/procedure',
+		path: '/:base/procedure',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/procedure/:id',
+		path: '/:base/procedure/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/procedure/:id',
+		path: '/:base/procedure/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/procedure/procedure.controller.js
+++ b/src/server/profiles/procedure/procedure.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific procedure & bundle
-		let Procedure = require(resolveFromVersion(version, 'uscore/Procedure'));
+		let Procedure = require(resolveFromVersion(base, 'uscore/Procedure'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Procedure, results, {
+				responseUtils.handleBundleReadResponse( res, base, Procedure, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -31,17 +31,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific procedure
-		let Procedure = require(resolveFromVersion(version, 'uscore/Procedure'));
+		let Procedure = require(resolveFromVersion(base, 'uscore/Procedure'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Procedure, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Procedure, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -53,14 +53,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific procedure
-		let Procedure = require(resolveFromVersion(version, 'uscore/Procedure'));
+		let Procedure = require(resolveFromVersion(base, 'uscore/Procedure'));
 		// Validate the resource type before creating it
 		if (Procedure.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Procedure.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new procedure resource and pass it to the service
@@ -69,11 +69,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Procedure.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Procedure.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -85,14 +85,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific procedure
-		let Procedure = require(resolveFromVersion(version, 'uscore/Procedure'));
+		let Procedure = require(resolveFromVersion(base, 'uscore/Procedure'));
 		// Validate the resource type before creating it
 		if (Procedure.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Procedure.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new procedure resource and pass it to the service
@@ -101,11 +101,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Procedure.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Procedure.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -117,7 +117,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -125,7 +125,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/procedurerequest/procedurerequest.config.js
+++ b/src/server/profiles/procedurerequest/procedurerequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/procedurerequest',
+		path: '/:base/procedurerequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/procedurerequest/_search',
+		path: '/:base/procedurerequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/procedurerequest/:id',
+		path: '/:base/procedurerequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/procedurerequest',
+		path: '/:base/procedurerequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/procedurerequest/:id',
+		path: '/:base/procedurerequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/procedurerequest/:id',
+		path: '/:base/procedurerequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/procedurerequest/procedurerequest.controller.js
+++ b/src/server/profiles/procedurerequest/procedurerequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcedureRequest = require(resolveFromVersion(version, 'base/ProcedureRequest'));
+		let ProcedureRequest = require(resolveFromVersion(base, 'base/ProcedureRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ProcedureRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, ProcedureRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcedureRequest = require(resolveFromVersion(version, 'base/ProcedureRequest'));
+		let ProcedureRequest = require(resolveFromVersion(base, 'base/ProcedureRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ProcedureRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ProcedureRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcedureRequest = require(resolveFromVersion(version, 'base/ProcedureRequest'));
+		let ProcedureRequest = require(resolveFromVersion(base, 'base/ProcedureRequest'));
 		// Validate the resource type before creating it
 		if (ProcedureRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcedureRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ProcedureRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ProcedureRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcedureRequest = require(resolveFromVersion(version, 'base/ProcedureRequest'));
+		let ProcedureRequest = require(resolveFromVersion(base, 'base/ProcedureRequest'));
 		// Validate the resource type before creating it
 		if (ProcedureRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcedureRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ProcedureRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ProcedureRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/processrequest/processrequest.config.js
+++ b/src/server/profiles/processrequest/processrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/processrequest',
+		path: '/:base/processrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/processrequest/_search',
+		path: '/:base/processrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/processrequest/:id',
+		path: '/:base/processrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/processrequest',
+		path: '/:base/processrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/processrequest/:id',
+		path: '/:base/processrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/processrequest/:id',
+		path: '/:base/processrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/processrequest/processrequest.controller.js
+++ b/src/server/profiles/processrequest/processrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessRequest = require(resolveFromVersion(version, 'base/ProcessRequest'));
+		let ProcessRequest = require(resolveFromVersion(base, 'base/ProcessRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ProcessRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, ProcessRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessRequest = require(resolveFromVersion(version, 'base/ProcessRequest'));
+		let ProcessRequest = require(resolveFromVersion(base, 'base/ProcessRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ProcessRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ProcessRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessRequest = require(resolveFromVersion(version, 'base/ProcessRequest'));
+		let ProcessRequest = require(resolveFromVersion(base, 'base/ProcessRequest'));
 		// Validate the resource type before creating it
 		if (ProcessRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcessRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ProcessRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ProcessRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessRequest = require(resolveFromVersion(version, 'base/ProcessRequest'));
+		let ProcessRequest = require(resolveFromVersion(base, 'base/ProcessRequest'));
 		// Validate the resource type before creating it
 		if (ProcessRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcessRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ProcessRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ProcessRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/processresponse/processresponse.config.js
+++ b/src/server/profiles/processresponse/processresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/processresponse',
+		path: '/:base/processresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/processresponse/_search',
+		path: '/:base/processresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/processresponse/:id',
+		path: '/:base/processresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/processresponse',
+		path: '/:base/processresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/processresponse/:id',
+		path: '/:base/processresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/processresponse/:id',
+		path: '/:base/processresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/processresponse/processresponse.controller.js
+++ b/src/server/profiles/processresponse/processresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessResponse = require(resolveFromVersion(version, 'base/ProcessResponse'));
+		let ProcessResponse = require(resolveFromVersion(base, 'base/ProcessResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ProcessResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, ProcessResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessResponse = require(resolveFromVersion(version, 'base/ProcessResponse'));
+		let ProcessResponse = require(resolveFromVersion(base, 'base/ProcessResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ProcessResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ProcessResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessResponse = require(resolveFromVersion(version, 'base/ProcessResponse'));
+		let ProcessResponse = require(resolveFromVersion(base, 'base/ProcessResponse'));
 		// Validate the resource type before creating it
 		if (ProcessResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcessResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ProcessResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ProcessResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ProcessResponse = require(resolveFromVersion(version, 'base/ProcessResponse'));
+		let ProcessResponse = require(resolveFromVersion(base, 'base/ProcessResponse'));
 		// Validate the resource type before creating it
 		if (ProcessResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ProcessResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ProcessResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ProcessResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/provenance/provenance.config.js
+++ b/src/server/profiles/provenance/provenance.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/provenance',
+		path: '/:base/provenance',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/provenance/_search',
+		path: '/:base/provenance/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/provenance/:id',
+		path: '/:base/provenance/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/provenance',
+		path: '/:base/provenance',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/provenance/:id',
+		path: '/:base/provenance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/provenance/:id',
+		path: '/:base/provenance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/provenance/provenance.controller.js
+++ b/src/server/profiles/provenance/provenance.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Provenance = require(resolveFromVersion(version, 'base/Provenance'));
+		let Provenance = require(resolveFromVersion(base, 'base/Provenance'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Provenance, results, {
+				responseUtils.handleBundleReadResponse( res, base, Provenance, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Provenance = require(resolveFromVersion(version, 'base/Provenance'));
+		let Provenance = require(resolveFromVersion(base, 'base/Provenance'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Provenance, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Provenance, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Provenance = require(resolveFromVersion(version, 'base/Provenance'));
+		let Provenance = require(resolveFromVersion(base, 'base/Provenance'));
 		// Validate the resource type before creating it
 		if (Provenance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Provenance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Provenance.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Provenance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Provenance = require(resolveFromVersion(version, 'base/Provenance'));
+		let Provenance = require(resolveFromVersion(base, 'base/Provenance'));
 		// Validate the resource type before creating it
 		if (Provenance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Provenance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Provenance.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Provenance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/questionnaire/questionnaire.config.js
+++ b/src/server/profiles/questionnaire/questionnaire.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/questionnaire',
+		path: '/:base/questionnaire',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/questionnaire/_search',
+		path: '/:base/questionnaire/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/questionnaire/:id',
+		path: '/:base/questionnaire/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/questionnaire',
+		path: '/:base/questionnaire',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/questionnaire/:id',
+		path: '/:base/questionnaire/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/questionnaire/:id',
+		path: '/:base/questionnaire/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/questionnaire/questionnaire.controller.js
+++ b/src/server/profiles/questionnaire/questionnaire.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Questionnaire = require(resolveFromVersion(version, 'base/Questionnaire'));
+		let Questionnaire = require(resolveFromVersion(base, 'base/Questionnaire'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Questionnaire, results, {
+				responseUtils.handleBundleReadResponse( res, base, Questionnaire, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Questionnaire = require(resolveFromVersion(version, 'base/Questionnaire'));
+		let Questionnaire = require(resolveFromVersion(base, 'base/Questionnaire'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Questionnaire, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Questionnaire, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Questionnaire = require(resolveFromVersion(version, 'base/Questionnaire'));
+		let Questionnaire = require(resolveFromVersion(base, 'base/Questionnaire'));
 		// Validate the resource type before creating it
 		if (Questionnaire.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Questionnaire.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Questionnaire.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Questionnaire.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Questionnaire = require(resolveFromVersion(version, 'base/Questionnaire'));
+		let Questionnaire = require(resolveFromVersion(base, 'base/Questionnaire'));
 		// Validate the resource type before creating it
 		if (Questionnaire.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Questionnaire.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Questionnaire.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Questionnaire.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/questionnaireresponse/questionnaireresponse.config.js
+++ b/src/server/profiles/questionnaireresponse/questionnaireresponse.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/questionnaireresponse',
+		path: '/:base/questionnaireresponse',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/questionnaireresponse/_search',
+		path: '/:base/questionnaireresponse/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/questionnaireresponse/:id',
+		path: '/:base/questionnaireresponse/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/questionnaireresponse',
+		path: '/:base/questionnaireresponse',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/questionnaireresponse/:id',
+		path: '/:base/questionnaireresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/questionnaireresponse/:id',
+		path: '/:base/questionnaireresponse/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
+++ b/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let QuestionnaireResponse = require(resolveFromVersion(version, 'base/QuestionnaireResponse'));
+		let QuestionnaireResponse = require(resolveFromVersion(base, 'base/QuestionnaireResponse'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, QuestionnaireResponse, results, {
+				responseUtils.handleBundleReadResponse( res, base, QuestionnaireResponse, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let QuestionnaireResponse = require(resolveFromVersion(version, 'base/QuestionnaireResponse'));
+		let QuestionnaireResponse = require(resolveFromVersion(base, 'base/QuestionnaireResponse'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, QuestionnaireResponse, results)
+				responseUtils.handleSingleReadResponse(res, next, base, QuestionnaireResponse, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let QuestionnaireResponse = require(resolveFromVersion(version, 'base/QuestionnaireResponse'));
+		let QuestionnaireResponse = require(resolveFromVersion(base, 'base/QuestionnaireResponse'));
 		// Validate the resource type before creating it
 		if (QuestionnaireResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${QuestionnaireResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, QuestionnaireResponse.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, QuestionnaireResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let QuestionnaireResponse = require(resolveFromVersion(version, 'base/QuestionnaireResponse'));
+		let QuestionnaireResponse = require(resolveFromVersion(base, 'base/QuestionnaireResponse'));
 		// Validate the resource type before creating it
 		if (QuestionnaireResponse.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${QuestionnaireResponse.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, QuestionnaireResponse.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, QuestionnaireResponse.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/referralrequest/referralrequest.config.js
+++ b/src/server/profiles/referralrequest/referralrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/referralrequest',
+		path: '/:base/referralrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/referralrequest/_search',
+		path: '/:base/referralrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/referralrequest/:id',
+		path: '/:base/referralrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/referralrequest',
+		path: '/:base/referralrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/referralrequest/:id',
+		path: '/:base/referralrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/referralrequest/:id',
+		path: '/:base/referralrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/referralrequest/referralrequest.controller.js
+++ b/src/server/profiles/referralrequest/referralrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ReferralRequest = require(resolveFromVersion(version, 'base/ReferralRequest'));
+		let ReferralRequest = require(resolveFromVersion(base, 'base/ReferralRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ReferralRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, ReferralRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ReferralRequest = require(resolveFromVersion(version, 'base/ReferralRequest'));
+		let ReferralRequest = require(resolveFromVersion(base, 'base/ReferralRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ReferralRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ReferralRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ReferralRequest = require(resolveFromVersion(version, 'base/ReferralRequest'));
+		let ReferralRequest = require(resolveFromVersion(base, 'base/ReferralRequest'));
 		// Validate the resource type before creating it
 		if (ReferralRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ReferralRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ReferralRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ReferralRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ReferralRequest = require(resolveFromVersion(version, 'base/ReferralRequest'));
+		let ReferralRequest = require(resolveFromVersion(base, 'base/ReferralRequest'));
 		// Validate the resource type before creating it
 		if (ReferralRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ReferralRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ReferralRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ReferralRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/relatedperson/relatedperson.config.js
+++ b/src/server/profiles/relatedperson/relatedperson.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/relatedperson',
+		path: '/:base/relatedperson',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/relatedperson/_search',
+		path: '/:base/relatedperson/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/relatedperson/:id',
+		path: '/:base/relatedperson/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/relatedperson',
+		path: '/:base/relatedperson',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/relatedperson/:id',
+		path: '/:base/relatedperson/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/relatedperson/:id',
+		path: '/:base/relatedperson/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/relatedperson/relatedperson.controller.js
+++ b/src/server/profiles/relatedperson/relatedperson.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RelatedPerson = require(resolveFromVersion(version, 'base/RelatedPerson'));
+		let RelatedPerson = require(resolveFromVersion(base, 'base/RelatedPerson'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, RelatedPerson, results, {
+				responseUtils.handleBundleReadResponse( res, base, RelatedPerson, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RelatedPerson = require(resolveFromVersion(version, 'base/RelatedPerson'));
+		let RelatedPerson = require(resolveFromVersion(base, 'base/RelatedPerson'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, RelatedPerson, results)
+				responseUtils.handleSingleReadResponse(res, next, base, RelatedPerson, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RelatedPerson = require(resolveFromVersion(version, 'base/RelatedPerson'));
+		let RelatedPerson = require(resolveFromVersion(base, 'base/RelatedPerson'));
 		// Validate the resource type before creating it
 		if (RelatedPerson.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RelatedPerson.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, RelatedPerson.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, RelatedPerson.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RelatedPerson = require(resolveFromVersion(version, 'base/RelatedPerson'));
+		let RelatedPerson = require(resolveFromVersion(base, 'base/RelatedPerson'));
 		// Validate the resource type before creating it
 		if (RelatedPerson.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RelatedPerson.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, RelatedPerson.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, RelatedPerson.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/requestgroup/requestgroup.config.js
+++ b/src/server/profiles/requestgroup/requestgroup.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/requestgroup',
+		path: '/:base/requestgroup',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/requestgroup/_search',
+		path: '/:base/requestgroup/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/requestgroup/:id',
+		path: '/:base/requestgroup/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/requestgroup',
+		path: '/:base/requestgroup',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/requestgroup/:id',
+		path: '/:base/requestgroup/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/requestgroup/:id',
+		path: '/:base/requestgroup/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/requestgroup/requestgroup.controller.js
+++ b/src/server/profiles/requestgroup/requestgroup.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RequestGroup = require(resolveFromVersion(version, 'base/RequestGroup'));
+		let RequestGroup = require(resolveFromVersion(base, 'base/RequestGroup'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, RequestGroup, results, {
+				responseUtils.handleBundleReadResponse( res, base, RequestGroup, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RequestGroup = require(resolveFromVersion(version, 'base/RequestGroup'));
+		let RequestGroup = require(resolveFromVersion(base, 'base/RequestGroup'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, RequestGroup, results)
+				responseUtils.handleSingleReadResponse(res, next, base, RequestGroup, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RequestGroup = require(resolveFromVersion(version, 'base/RequestGroup'));
+		let RequestGroup = require(resolveFromVersion(base, 'base/RequestGroup'));
 		// Validate the resource type before creating it
 		if (RequestGroup.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RequestGroup.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, RequestGroup.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, RequestGroup.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RequestGroup = require(resolveFromVersion(version, 'base/RequestGroup'));
+		let RequestGroup = require(resolveFromVersion(base, 'base/RequestGroup'));
 		// Validate the resource type before creating it
 		if (RequestGroup.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RequestGroup.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, RequestGroup.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, RequestGroup.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/researchstudy/researchstudy.config.js
+++ b/src/server/profiles/researchstudy/researchstudy.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/researchstudy',
+		path: '/:base/researchstudy',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/researchstudy/_search',
+		path: '/:base/researchstudy/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/researchstudy/:id',
+		path: '/:base/researchstudy/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/researchstudy',
+		path: '/:base/researchstudy',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/researchstudy/:id',
+		path: '/:base/researchstudy/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/researchstudy/:id',
+		path: '/:base/researchstudy/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/researchstudy/researchstudy.controller.js
+++ b/src/server/profiles/researchstudy/researchstudy.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchStudy = require(resolveFromVersion(version, 'base/ResearchStudy'));
+		let ResearchStudy = require(resolveFromVersion(base, 'base/ResearchStudy'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ResearchStudy, results, {
+				responseUtils.handleBundleReadResponse( res, base, ResearchStudy, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchStudy = require(resolveFromVersion(version, 'base/ResearchStudy'));
+		let ResearchStudy = require(resolveFromVersion(base, 'base/ResearchStudy'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ResearchStudy, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ResearchStudy, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchStudy = require(resolveFromVersion(version, 'base/ResearchStudy'));
+		let ResearchStudy = require(resolveFromVersion(base, 'base/ResearchStudy'));
 		// Validate the resource type before creating it
 		if (ResearchStudy.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ResearchStudy.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ResearchStudy.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ResearchStudy.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchStudy = require(resolveFromVersion(version, 'base/ResearchStudy'));
+		let ResearchStudy = require(resolveFromVersion(base, 'base/ResearchStudy'));
 		// Validate the resource type before creating it
 		if (ResearchStudy.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ResearchStudy.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ResearchStudy.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ResearchStudy.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/researchsubject/researchsubject.config.js
+++ b/src/server/profiles/researchsubject/researchsubject.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/researchsubject',
+		path: '/:base/researchsubject',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/researchsubject/_search',
+		path: '/:base/researchsubject/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/researchsubject/:id',
+		path: '/:base/researchsubject/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/researchsubject',
+		path: '/:base/researchsubject',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/researchsubject/:id',
+		path: '/:base/researchsubject/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/researchsubject/:id',
+		path: '/:base/researchsubject/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/researchsubject/researchsubject.controller.js
+++ b/src/server/profiles/researchsubject/researchsubject.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchSubject = require(resolveFromVersion(version, 'base/ResearchSubject'));
+		let ResearchSubject = require(resolveFromVersion(base, 'base/ResearchSubject'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ResearchSubject, results, {
+				responseUtils.handleBundleReadResponse( res, base, ResearchSubject, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchSubject = require(resolveFromVersion(version, 'base/ResearchSubject'));
+		let ResearchSubject = require(resolveFromVersion(base, 'base/ResearchSubject'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ResearchSubject, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ResearchSubject, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchSubject = require(resolveFromVersion(version, 'base/ResearchSubject'));
+		let ResearchSubject = require(resolveFromVersion(base, 'base/ResearchSubject'));
 		// Validate the resource type before creating it
 		if (ResearchSubject.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ResearchSubject.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ResearchSubject.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ResearchSubject.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ResearchSubject = require(resolveFromVersion(version, 'base/ResearchSubject'));
+		let ResearchSubject = require(resolveFromVersion(base, 'base/ResearchSubject'));
 		// Validate the resource type before creating it
 		if (ResearchSubject.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ResearchSubject.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ResearchSubject.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ResearchSubject.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/riskassessment/riskassessment.config.js
+++ b/src/server/profiles/riskassessment/riskassessment.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/riskassessment',
+		path: '/:base/riskassessment',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/riskassessment/_search',
+		path: '/:base/riskassessment/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/riskassessment/:id',
+		path: '/:base/riskassessment/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/riskassessment',
+		path: '/:base/riskassessment',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/riskassessment/:id',
+		path: '/:base/riskassessment/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/riskassessment/:id',
+		path: '/:base/riskassessment/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/riskassessment/riskassessment.controller.js
+++ b/src/server/profiles/riskassessment/riskassessment.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RiskAssessment = require(resolveFromVersion(version, 'base/RiskAssessment'));
+		let RiskAssessment = require(resolveFromVersion(base, 'base/RiskAssessment'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, RiskAssessment, results, {
+				responseUtils.handleBundleReadResponse( res, base, RiskAssessment, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let RiskAssessment = require(resolveFromVersion(version, 'base/RiskAssessment'));
+		let RiskAssessment = require(resolveFromVersion(base, 'base/RiskAssessment'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, RiskAssessment, results)
+				responseUtils.handleSingleReadResponse(res, next, base, RiskAssessment, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RiskAssessment = require(resolveFromVersion(version, 'base/RiskAssessment'));
+		let RiskAssessment = require(resolveFromVersion(base, 'base/RiskAssessment'));
 		// Validate the resource type before creating it
 		if (RiskAssessment.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RiskAssessment.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, RiskAssessment.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, RiskAssessment.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let RiskAssessment = require(resolveFromVersion(version, 'base/RiskAssessment'));
+		let RiskAssessment = require(resolveFromVersion(base, 'base/RiskAssessment'));
 		// Validate the resource type before creating it
 		if (RiskAssessment.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${RiskAssessment.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, RiskAssessment.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, RiskAssessment.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/schedule/schedule.config.js
+++ b/src/server/profiles/schedule/schedule.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/schedule',
+		path: '/:base/schedule',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/schedule/_search',
+		path: '/:base/schedule/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/schedule/:id',
+		path: '/:base/schedule/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/schedule',
+		path: '/:base/schedule',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/schedule/:id',
+		path: '/:base/schedule/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/schedule/:id',
+		path: '/:base/schedule/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/schedule/schedule.controller.js
+++ b/src/server/profiles/schedule/schedule.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Schedule = require(resolveFromVersion(version, 'base/Schedule'));
+		let Schedule = require(resolveFromVersion(base, 'base/Schedule'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Schedule, results, {
+				responseUtils.handleBundleReadResponse( res, base, Schedule, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Schedule = require(resolveFromVersion(version, 'base/Schedule'));
+		let Schedule = require(resolveFromVersion(base, 'base/Schedule'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Schedule, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Schedule, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Schedule = require(resolveFromVersion(version, 'base/Schedule'));
+		let Schedule = require(resolveFromVersion(base, 'base/Schedule'));
 		// Validate the resource type before creating it
 		if (Schedule.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Schedule.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Schedule.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Schedule.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Schedule = require(resolveFromVersion(version, 'base/Schedule'));
+		let Schedule = require(resolveFromVersion(base, 'base/Schedule'));
 		// Validate the resource type before creating it
 		if (Schedule.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Schedule.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Schedule.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Schedule.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/searchparameter/searchparameter.config.js
+++ b/src/server/profiles/searchparameter/searchparameter.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/searchparameter',
+		path: '/:base/searchparameter',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/searchparameter/_search',
+		path: '/:base/searchparameter/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/searchparameter/:id',
+		path: '/:base/searchparameter/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/searchparameter',
+		path: '/:base/searchparameter',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/searchparameter/:id',
+		path: '/:base/searchparameter/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/searchparameter/:id',
+		path: '/:base/searchparameter/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/searchparameter/searchparameter.controller.js
+++ b/src/server/profiles/searchparameter/searchparameter.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SearchParameter = require(resolveFromVersion(version, 'base/SearchParameter'));
+		let SearchParameter = require(resolveFromVersion(base, 'base/SearchParameter'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, SearchParameter, results, {
+				responseUtils.handleBundleReadResponse( res, base, SearchParameter, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SearchParameter = require(resolveFromVersion(version, 'base/SearchParameter'));
+		let SearchParameter = require(resolveFromVersion(base, 'base/SearchParameter'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, SearchParameter, results)
+				responseUtils.handleSingleReadResponse(res, next, base, SearchParameter, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SearchParameter = require(resolveFromVersion(version, 'base/SearchParameter'));
+		let SearchParameter = require(resolveFromVersion(base, 'base/SearchParameter'));
 		// Validate the resource type before creating it
 		if (SearchParameter.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SearchParameter.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, SearchParameter.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, SearchParameter.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SearchParameter = require(resolveFromVersion(version, 'base/SearchParameter'));
+		let SearchParameter = require(resolveFromVersion(base, 'base/SearchParameter'));
 		// Validate the resource type before creating it
 		if (SearchParameter.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SearchParameter.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, SearchParameter.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, SearchParameter.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/sequence/sequence.config.js
+++ b/src/server/profiles/sequence/sequence.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/sequence',
+		path: '/:base/sequence',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/sequence/_search',
+		path: '/:base/sequence/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/sequence/:id',
+		path: '/:base/sequence/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/sequence',
+		path: '/:base/sequence',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/sequence/:id',
+		path: '/:base/sequence/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/sequence/:id',
+		path: '/:base/sequence/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/sequence/sequence.controller.js
+++ b/src/server/profiles/sequence/sequence.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Sequence = require(resolveFromVersion(version, 'base/Sequence'));
+		let Sequence = require(resolveFromVersion(base, 'base/Sequence'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Sequence, results, {
+				responseUtils.handleBundleReadResponse( res, base, Sequence, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Sequence = require(resolveFromVersion(version, 'base/Sequence'));
+		let Sequence = require(resolveFromVersion(base, 'base/Sequence'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Sequence, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Sequence, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Sequence = require(resolveFromVersion(version, 'base/Sequence'));
+		let Sequence = require(resolveFromVersion(base, 'base/Sequence'));
 		// Validate the resource type before creating it
 		if (Sequence.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Sequence.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Sequence.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Sequence.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Sequence = require(resolveFromVersion(version, 'base/Sequence'));
+		let Sequence = require(resolveFromVersion(base, 'base/Sequence'));
 		// Validate the resource type before creating it
 		if (Sequence.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Sequence.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Sequence.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Sequence.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/servicedefinition/servicedefinition.config.js
+++ b/src/server/profiles/servicedefinition/servicedefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/servicedefinition',
+		path: '/:base/servicedefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/servicedefinition/_search',
+		path: '/:base/servicedefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/servicedefinition/:id',
+		path: '/:base/servicedefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/servicedefinition',
+		path: '/:base/servicedefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/servicedefinition/:id',
+		path: '/:base/servicedefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/servicedefinition/:id',
+		path: '/:base/servicedefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/servicedefinition/servicedefinition.controller.js
+++ b/src/server/profiles/servicedefinition/servicedefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ServiceDefinition = require(resolveFromVersion(version, 'base/ServiceDefinition'));
+		let ServiceDefinition = require(resolveFromVersion(base, 'base/ServiceDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ServiceDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, ServiceDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ServiceDefinition = require(resolveFromVersion(version, 'base/ServiceDefinition'));
+		let ServiceDefinition = require(resolveFromVersion(base, 'base/ServiceDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ServiceDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ServiceDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ServiceDefinition = require(resolveFromVersion(version, 'base/ServiceDefinition'));
+		let ServiceDefinition = require(resolveFromVersion(base, 'base/ServiceDefinition'));
 		// Validate the resource type before creating it
 		if (ServiceDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ServiceDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ServiceDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ServiceDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ServiceDefinition = require(resolveFromVersion(version, 'base/ServiceDefinition'));
+		let ServiceDefinition = require(resolveFromVersion(base, 'base/ServiceDefinition'));
 		// Validate the resource type before creating it
 		if (ServiceDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ServiceDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ServiceDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ServiceDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/slot/slot.config.js
+++ b/src/server/profiles/slot/slot.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/slot',
+		path: '/:base/slot',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/slot/_search',
+		path: '/:base/slot/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/slot/:id',
+		path: '/:base/slot/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/slot',
+		path: '/:base/slot',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/slot/:id',
+		path: '/:base/slot/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/slot/:id',
+		path: '/:base/slot/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/slot/slot.controller.js
+++ b/src/server/profiles/slot/slot.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Slot = require(resolveFromVersion(version, 'base/Slot'));
+		let Slot = require(resolveFromVersion(base, 'base/Slot'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Slot, results, {
+				responseUtils.handleBundleReadResponse( res, base, Slot, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Slot = require(resolveFromVersion(version, 'base/Slot'));
+		let Slot = require(resolveFromVersion(base, 'base/Slot'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Slot, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Slot, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Slot = require(resolveFromVersion(version, 'base/Slot'));
+		let Slot = require(resolveFromVersion(base, 'base/Slot'));
 		// Validate the resource type before creating it
 		if (Slot.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Slot.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Slot.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Slot.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Slot = require(resolveFromVersion(version, 'base/Slot'));
+		let Slot = require(resolveFromVersion(base, 'base/Slot'));
 		// Validate the resource type before creating it
 		if (Slot.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Slot.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Slot.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Slot.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/specimen/specimen.config.js
+++ b/src/server/profiles/specimen/specimen.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/specimen',
+		path: '/:base/specimen',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/specimen/_search',
+		path: '/:base/specimen/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/specimen/:id',
+		path: '/:base/specimen/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/specimen',
+		path: '/:base/specimen',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/specimen/:id',
+		path: '/:base/specimen/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/specimen/:id',
+		path: '/:base/specimen/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/specimen/specimen.controller.js
+++ b/src/server/profiles/specimen/specimen.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Specimen = require(resolveFromVersion(version, 'base/Specimen'));
+		let Specimen = require(resolveFromVersion(base, 'base/Specimen'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Specimen, results, {
+				responseUtils.handleBundleReadResponse( res, base, Specimen, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Specimen = require(resolveFromVersion(version, 'base/Specimen'));
+		let Specimen = require(resolveFromVersion(base, 'base/Specimen'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Specimen, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Specimen, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Specimen = require(resolveFromVersion(version, 'base/Specimen'));
+		let Specimen = require(resolveFromVersion(base, 'base/Specimen'));
 		// Validate the resource type before creating it
 		if (Specimen.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Specimen.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Specimen.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Specimen.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Specimen = require(resolveFromVersion(version, 'base/Specimen'));
+		let Specimen = require(resolveFromVersion(base, 'base/Specimen'));
 		// Validate the resource type before creating it
 		if (Specimen.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Specimen.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Specimen.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Specimen.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/structuredefinition/structuredefinition.config.js
+++ b/src/server/profiles/structuredefinition/structuredefinition.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/structuredefinition',
+		path: '/:base/structuredefinition',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/structuredefinition/_search',
+		path: '/:base/structuredefinition/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/structuredefinition/:id',
+		path: '/:base/structuredefinition/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/structuredefinition',
+		path: '/:base/structuredefinition',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/structuredefinition/:id',
+		path: '/:base/structuredefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/structuredefinition/:id',
+		path: '/:base/structuredefinition/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/structuredefinition/structuredefinition.controller.js
+++ b/src/server/profiles/structuredefinition/structuredefinition.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let StructureDefinition = require(resolveFromVersion(version, 'base/StructureDefinition'));
+		let StructureDefinition = require(resolveFromVersion(base, 'base/StructureDefinition'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, StructureDefinition, results, {
+				responseUtils.handleBundleReadResponse( res, base, StructureDefinition, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let StructureDefinition = require(resolveFromVersion(version, 'base/StructureDefinition'));
+		let StructureDefinition = require(resolveFromVersion(base, 'base/StructureDefinition'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, StructureDefinition, results)
+				responseUtils.handleSingleReadResponse(res, next, base, StructureDefinition, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let StructureDefinition = require(resolveFromVersion(version, 'base/StructureDefinition'));
+		let StructureDefinition = require(resolveFromVersion(base, 'base/StructureDefinition'));
 		// Validate the resource type before creating it
 		if (StructureDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${StructureDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, StructureDefinition.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, StructureDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let StructureDefinition = require(resolveFromVersion(version, 'base/StructureDefinition'));
+		let StructureDefinition = require(resolveFromVersion(base, 'base/StructureDefinition'));
 		// Validate the resource type before creating it
 		if (StructureDefinition.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${StructureDefinition.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, StructureDefinition.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, StructureDefinition.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/structuremap/structuremap.config.js
+++ b/src/server/profiles/structuremap/structuremap.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/structuremap',
+		path: '/:base/structuremap',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/structuremap/_search',
+		path: '/:base/structuremap/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/structuremap/:id',
+		path: '/:base/structuremap/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/structuremap',
+		path: '/:base/structuremap',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/structuremap/:id',
+		path: '/:base/structuremap/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/structuremap/:id',
+		path: '/:base/structuremap/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/structuremap/structuremap.controller.js
+++ b/src/server/profiles/structuremap/structuremap.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let StructureMap = require(resolveFromVersion(version, 'base/StructureMap'));
+		let StructureMap = require(resolveFromVersion(base, 'base/StructureMap'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, StructureMap, results, {
+				responseUtils.handleBundleReadResponse( res, base, StructureMap, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let StructureMap = require(resolveFromVersion(version, 'base/StructureMap'));
+		let StructureMap = require(resolveFromVersion(base, 'base/StructureMap'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, StructureMap, results)
+				responseUtils.handleSingleReadResponse(res, next, base, StructureMap, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let StructureMap = require(resolveFromVersion(version, 'base/StructureMap'));
+		let StructureMap = require(resolveFromVersion(base, 'base/StructureMap'));
 		// Validate the resource type before creating it
 		if (StructureMap.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${StructureMap.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, StructureMap.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, StructureMap.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let StructureMap = require(resolveFromVersion(version, 'base/StructureMap'));
+		let StructureMap = require(resolveFromVersion(base, 'base/StructureMap'));
 		// Validate the resource type before creating it
 		if (StructureMap.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${StructureMap.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, StructureMap.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, StructureMap.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/subscription/subscription.config.js
+++ b/src/server/profiles/subscription/subscription.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/subscription',
+		path: '/:base/subscription',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/subscription/_search',
+		path: '/:base/subscription/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/subscription/:id',
+		path: '/:base/subscription/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/subscription',
+		path: '/:base/subscription',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/subscription/:id',
+		path: '/:base/subscription/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/subscription/:id',
+		path: '/:base/subscription/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/subscription/subscription.controller.js
+++ b/src/server/profiles/subscription/subscription.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Subscription = require(resolveFromVersion(version, 'base/Subscription'));
+		let Subscription = require(resolveFromVersion(base, 'base/Subscription'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Subscription, results, {
+				responseUtils.handleBundleReadResponse( res, base, Subscription, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Subscription = require(resolveFromVersion(version, 'base/Subscription'));
+		let Subscription = require(resolveFromVersion(base, 'base/Subscription'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Subscription, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Subscription, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Subscription = require(resolveFromVersion(version, 'base/Subscription'));
+		let Subscription = require(resolveFromVersion(base, 'base/Subscription'));
 		// Validate the resource type before creating it
 		if (Subscription.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Subscription.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Subscription.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Subscription.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Subscription = require(resolveFromVersion(version, 'base/Subscription'));
+		let Subscription = require(resolveFromVersion(base, 'base/Subscription'));
 		// Validate the resource type before creating it
 		if (Subscription.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Subscription.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Subscription.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Subscription.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/substance/substance.config.js
+++ b/src/server/profiles/substance/substance.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/substance',
+		path: '/:base/substance',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/substance/_search',
+		path: '/:base/substance/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/substance/:id',
+		path: '/:base/substance/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/substance',
+		path: '/:base/substance',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/substance/:id',
+		path: '/:base/substance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/substance/:id',
+		path: '/:base/substance/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/substance/substance.controller.js
+++ b/src/server/profiles/substance/substance.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Substance = require(resolveFromVersion(version, 'base/Substance'));
+		let Substance = require(resolveFromVersion(base, 'base/Substance'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Substance, results, {
+				responseUtils.handleBundleReadResponse( res, base, Substance, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Substance = require(resolveFromVersion(version, 'base/Substance'));
+		let Substance = require(resolveFromVersion(base, 'base/Substance'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Substance, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Substance, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Substance = require(resolveFromVersion(version, 'base/Substance'));
+		let Substance = require(resolveFromVersion(base, 'base/Substance'));
 		// Validate the resource type before creating it
 		if (Substance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Substance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Substance.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Substance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Substance = require(resolveFromVersion(version, 'base/Substance'));
+		let Substance = require(resolveFromVersion(base, 'base/Substance'));
 		// Validate the resource type before creating it
 		if (Substance.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Substance.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Substance.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Substance.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/supplydelivery/supplydelivery.config.js
+++ b/src/server/profiles/supplydelivery/supplydelivery.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/supplydelivery',
+		path: '/:base/supplydelivery',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/supplydelivery/_search',
+		path: '/:base/supplydelivery/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/supplydelivery/:id',
+		path: '/:base/supplydelivery/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/supplydelivery',
+		path: '/:base/supplydelivery',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/supplydelivery/:id',
+		path: '/:base/supplydelivery/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/supplydelivery/:id',
+		path: '/:base/supplydelivery/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/supplydelivery/supplydelivery.controller.js
+++ b/src/server/profiles/supplydelivery/supplydelivery.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyDelivery = require(resolveFromVersion(version, 'base/SupplyDelivery'));
+		let SupplyDelivery = require(resolveFromVersion(base, 'base/SupplyDelivery'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, SupplyDelivery, results, {
+				responseUtils.handleBundleReadResponse( res, base, SupplyDelivery, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyDelivery = require(resolveFromVersion(version, 'base/SupplyDelivery'));
+		let SupplyDelivery = require(resolveFromVersion(base, 'base/SupplyDelivery'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, SupplyDelivery, results)
+				responseUtils.handleSingleReadResponse(res, next, base, SupplyDelivery, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyDelivery = require(resolveFromVersion(version, 'base/SupplyDelivery'));
+		let SupplyDelivery = require(resolveFromVersion(base, 'base/SupplyDelivery'));
 		// Validate the resource type before creating it
 		if (SupplyDelivery.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SupplyDelivery.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, SupplyDelivery.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, SupplyDelivery.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyDelivery = require(resolveFromVersion(version, 'base/SupplyDelivery'));
+		let SupplyDelivery = require(resolveFromVersion(base, 'base/SupplyDelivery'));
 		// Validate the resource type before creating it
 		if (SupplyDelivery.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SupplyDelivery.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, SupplyDelivery.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, SupplyDelivery.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/supplyrequest/supplyrequest.config.js
+++ b/src/server/profiles/supplyrequest/supplyrequest.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/supplyrequest',
+		path: '/:base/supplyrequest',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/supplyrequest/_search',
+		path: '/:base/supplyrequest/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/supplyrequest/:id',
+		path: '/:base/supplyrequest/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/supplyrequest',
+		path: '/:base/supplyrequest',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/supplyrequest/:id',
+		path: '/:base/supplyrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/supplyrequest/:id',
+		path: '/:base/supplyrequest/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/supplyrequest/supplyrequest.controller.js
+++ b/src/server/profiles/supplyrequest/supplyrequest.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyRequest = require(resolveFromVersion(version, 'base/SupplyRequest'));
+		let SupplyRequest = require(resolveFromVersion(base, 'base/SupplyRequest'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, SupplyRequest, results, {
+				responseUtils.handleBundleReadResponse( res, base, SupplyRequest, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyRequest = require(resolveFromVersion(version, 'base/SupplyRequest'));
+		let SupplyRequest = require(resolveFromVersion(base, 'base/SupplyRequest'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, SupplyRequest, results)
+				responseUtils.handleSingleReadResponse(res, next, base, SupplyRequest, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyRequest = require(resolveFromVersion(version, 'base/SupplyRequest'));
+		let SupplyRequest = require(resolveFromVersion(base, 'base/SupplyRequest'));
 		// Validate the resource type before creating it
 		if (SupplyRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SupplyRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, SupplyRequest.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, SupplyRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let SupplyRequest = require(resolveFromVersion(version, 'base/SupplyRequest'));
+		let SupplyRequest = require(resolveFromVersion(base, 'base/SupplyRequest'));
 		// Validate the resource type before creating it
 		if (SupplyRequest.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${SupplyRequest.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, SupplyRequest.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, SupplyRequest.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/task/task.config.js
+++ b/src/server/profiles/task/task.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/task',
+		path: '/:base/task',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/task/_search',
+		path: '/:base/task/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/task/:id',
+		path: '/:base/task/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/task',
+		path: '/:base/task',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/task/:id',
+		path: '/:base/task/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/task/:id',
+		path: '/:base/task/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/task/task.controller.js
+++ b/src/server/profiles/task/task.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Task = require(resolveFromVersion(version, 'base/Task'));
+		let Task = require(resolveFromVersion(base, 'base/Task'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, Task, results, {
+				responseUtils.handleBundleReadResponse( res, base, Task, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let Task = require(resolveFromVersion(version, 'base/Task'));
+		let Task = require(resolveFromVersion(base, 'base/Task'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, Task, results)
+				responseUtils.handleSingleReadResponse(res, next, base, Task, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Task = require(resolveFromVersion(version, 'base/Task'));
+		let Task = require(resolveFromVersion(base, 'base/Task'));
 		// Validate the resource type before creating it
 		if (Task.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Task.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, Task.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, Task.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let Task = require(resolveFromVersion(version, 'base/Task'));
+		let Task = require(resolveFromVersion(base, 'base/Task'));
 		// Validate the resource type before creating it
 		if (Task.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${Task.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, Task.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, Task.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/testreport/testreport.config.js
+++ b/src/server/profiles/testreport/testreport.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/testreport',
+		path: '/:base/testreport',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/testreport/_search',
+		path: '/:base/testreport/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/testreport/:id',
+		path: '/:base/testreport/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/testreport',
+		path: '/:base/testreport',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/testreport/:id',
+		path: '/:base/testreport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/testreport/:id',
+		path: '/:base/testreport/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/testreport/testreport.controller.js
+++ b/src/server/profiles/testreport/testreport.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let TestReport = require(resolveFromVersion(version, 'base/TestReport'));
+		let TestReport = require(resolveFromVersion(base, 'base/TestReport'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, TestReport, results, {
+				responseUtils.handleBundleReadResponse( res, base, TestReport, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let TestReport = require(resolveFromVersion(version, 'base/TestReport'));
+		let TestReport = require(resolveFromVersion(base, 'base/TestReport'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, TestReport, results)
+				responseUtils.handleSingleReadResponse(res, next, base, TestReport, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let TestReport = require(resolveFromVersion(version, 'base/TestReport'));
+		let TestReport = require(resolveFromVersion(base, 'base/TestReport'));
 		// Validate the resource type before creating it
 		if (TestReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${TestReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, TestReport.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, TestReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let TestReport = require(resolveFromVersion(version, 'base/TestReport'));
+		let TestReport = require(resolveFromVersion(base, 'base/TestReport'));
 		// Validate the resource type before creating it
 		if (TestReport.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${TestReport.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, TestReport.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, TestReport.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/testscript/testscript.config.js
+++ b/src/server/profiles/testscript/testscript.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/testscript',
+		path: '/:base/testscript',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/testscript/_search',
+		path: '/:base/testscript/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/testscript/:id',
+		path: '/:base/testscript/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/testscript',
+		path: '/:base/testscript',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/testscript/:id',
+		path: '/:base/testscript/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/testscript/:id',
+		path: '/:base/testscript/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/testscript/testscript.controller.js
+++ b/src/server/profiles/testscript/testscript.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let TestScript = require(resolveFromVersion(version, 'base/TestScript'));
+		let TestScript = require(resolveFromVersion(base, 'base/TestScript'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, TestScript, results, {
+				responseUtils.handleBundleReadResponse( res, base, TestScript, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let TestScript = require(resolveFromVersion(version, 'base/TestScript'));
+		let TestScript = require(resolveFromVersion(base, 'base/TestScript'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, TestScript, results)
+				responseUtils.handleSingleReadResponse(res, next, base, TestScript, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let TestScript = require(resolveFromVersion(version, 'base/TestScript'));
+		let TestScript = require(resolveFromVersion(base, 'base/TestScript'));
 		// Validate the resource type before creating it
 		if (TestScript.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${TestScript.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, TestScript.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, TestScript.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let TestScript = require(resolveFromVersion(version, 'base/TestScript'));
+		let TestScript = require(resolveFromVersion(base, 'base/TestScript'));
 		// Validate the resource type before creating it
 		if (TestScript.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${TestScript.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, TestScript.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, TestScript.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/valueset/valueset.config.js
+++ b/src/server/profiles/valueset/valueset.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/valueset',
+		path: '/:base/valueset',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/valueset/_search',
+		path: '/:base/valueset/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/valueset/:id',
+		path: '/:base/valueset/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/valueset',
+		path: '/:base/valueset',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/valueset/:id',
+		path: '/:base/valueset/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/valueset/:id',
+		path: '/:base/valueset/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/valueset/valueset.controller.js
+++ b/src/server/profiles/valueset/valueset.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ValueSet = require(resolveFromVersion(version, 'base/ValueSet'));
+		let ValueSet = require(resolveFromVersion(base, 'base/ValueSet'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, ValueSet, results, {
+				responseUtils.handleBundleReadResponse( res, base, ValueSet, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let ValueSet = require(resolveFromVersion(version, 'base/ValueSet'));
+		let ValueSet = require(resolveFromVersion(base, 'base/ValueSet'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, ValueSet, results)
+				responseUtils.handleSingleReadResponse(res, next, base, ValueSet, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ValueSet = require(resolveFromVersion(version, 'base/ValueSet'));
+		let ValueSet = require(resolveFromVersion(base, 'base/ValueSet'));
 		// Validate the resource type before creating it
 		if (ValueSet.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ValueSet.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, ValueSet.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, ValueSet.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let ValueSet = require(resolveFromVersion(version, 'base/ValueSet'));
+		let ValueSet = require(resolveFromVersion(base, 'base/ValueSet'));
 		// Validate the resource type before creating it
 		if (ValueSet.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${ValueSet.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, ValueSet.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, ValueSet.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/profiles/visionprescription/visionprescription.config.js
+++ b/src/server/profiles/visionprescription/visionprescription.config.js
@@ -14,29 +14,29 @@ let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
 	.map((arg_name) => Object.assign({ versions: VERSIONS.STU3 }, resource_specific_args[arg_name]));
 
 const resource_all_arguments = [
-	route_args.VERSION,	...common_args_array, ...resource_args_array,
+	route_args.BASE,	...common_args_array, ...resource_args_array,
 ];
 
 let routes = [
 	{
 		type: 'get',
-		path: '/:version/visionprescription',
+		path: '/:base/visionprescription',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'post',
-		path: '/:version/visionprescription/_search',
+		path: '/:base/visionprescription/_search',
 		args: resource_all_arguments,
 		scopes: read_only_scopes,
 		controller: controller.search
 	},
 	{
 		type: 'get',
-		path: '/:version/visionprescription/:id',
+		path: '/:base/visionprescription/:id',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			route_args.ID
 		],
 		scopes: read_only_scopes,
@@ -44,9 +44,9 @@ let routes = [
 	},
 	{
 		type: 'post',
-		path: '/:version/visionprescription',
+		path: '/:base/visionprescription',
 		args: [
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_ID,
 			write_args.RESOURCE_BODY
 		],
@@ -55,10 +55,10 @@ let routes = [
 	},
 	{
 		type: 'put',
-		path: '/:version/visionprescription/:id',
+		path: '/:base/visionprescription/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,
@@ -66,10 +66,10 @@ let routes = [
 	},
 	{
 		type: 'delete',
-		path: '/:version/visionprescription/:id',
+		path: '/:base/visionprescription/:id',
 		args: [
 			route_args.ID,
-			route_args.VERSION,
+			route_args.BASE,
 			write_args.RESOURCE_BODY
 		],
 		scopes: write_only_scopes,

--- a/src/server/profiles/visionprescription/visionprescription.controller.js
+++ b/src/server/profiles/visionprescription/visionprescription.controller.js
@@ -7,19 +7,19 @@ module.exports.search = function search ({ profile, logger, config, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let VisionPrescription = require(resolveFromVersion(version, 'base/VisionPrescription'));
+		let VisionPrescription = require(resolveFromVersion(base, 'base/VisionPrescription'));
 
 		return service.search(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleBundleReadResponse( res, version, VisionPrescription, results, {
+				responseUtils.handleBundleReadResponse( res, base, VisionPrescription, results, {
 					resourceUrl: config.auth.resourceServer
 				})
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 
@@ -30,17 +30,17 @@ module.exports.searchById = function searchById ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 		// Get a version specific resource
-		let VisionPrescription = require(resolveFromVersion(version, 'base/VisionPrescription'));
+		let VisionPrescription = require(resolveFromVersion(base, 'base/VisionPrescription'));
 
 		return service.searchById(req.sanitized_args, logger)
 			.then((results) =>
-				responseUtils.handleSingleReadResponse(res, next, version, VisionPrescription, results)
+				responseUtils.handleSingleReadResponse(res, next, base, VisionPrescription, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -52,14 +52,14 @@ module.exports.create = function create ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, resource_id, resource_body = {}} = req.sanitized_args;
+		let { base, resource_id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let VisionPrescription = require(resolveFromVersion(version, 'base/VisionPrescription'));
+		let VisionPrescription = require(resolveFromVersion(base, 'base/VisionPrescription'));
 		// Validate the resource type before creating it
 		if (VisionPrescription.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${VisionPrescription.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -68,11 +68,11 @@ module.exports.create = function create ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.create(args, logger)
 			.then((results) =>
-				responseUtils.handleCreateResponse(res, version, VisionPrescription.__resourceType, results)
+				responseUtils.handleCreateResponse(res, base, VisionPrescription.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -84,14 +84,14 @@ module.exports.update = function update ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version, id, resource_body = {}} = req.sanitized_args;
+		let { base, id, resource_body = {}} = req.sanitized_args;
 		// Get a version specific resource
-		let VisionPrescription = require(resolveFromVersion(version, 'base/VisionPrescription'));
+		let VisionPrescription = require(resolveFromVersion(base, 'base/VisionPrescription'));
 		// Validate the resource type before creating it
 		if (VisionPrescription.__resourceType !== resource_body.resourceType) {
 			return next(errors.invalidParameter(
 				`'resourceType' expected to have value of '${VisionPrescription.__resourceType}', received '${resource_body.resourceType}'`,
-				version
+				base
 			));
 		}
 		// Create a new resource and pass it to the service
@@ -100,11 +100,11 @@ module.exports.update = function update ({ profile, logger, app }) {
 		// Pass any new information to the underlying service
 		return service.update(args, logger)
 			.then((results) =>
-				responseUtils.handleUpdateResponse(res, version, VisionPrescription.__resourceType, results)
+				responseUtils.handleUpdateResponse(res, base, VisionPrescription.__resourceType, results)
 			)
 			.catch((err) => {
 				logger.error(err);
-				next(errors.internal(err.message, version));
+				next(errors.internal(err.message, base));
 			});
 	};
 };
@@ -116,7 +116,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 	let { serviceModule: service } = profile;
 
 	return (req, res, next) => {
-		let { version } = req.sanitized_args;
+		let { base } = req.sanitized_args;
 
 		return service.remove(req.sanitized_args, logger)
 			.then(() => responseUtils.handleDeleteResponse(res))
@@ -124,7 +124,7 @@ module.exports.remove = function remove ({ profile, logger, app }) {
 				// Log the error
 				logger.error(err);
 				// Pass the error back
-				responseUtils.handleDeleteRejection(res, next, version, err);
+				responseUtils.handleDeleteRejection(res, next, base, err);
 			});
 	};
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -174,12 +174,12 @@ class Server {
 		// Errors should be thrown with next and passed through
 		this.app.use((err, req, res, next) => {
 			// If there is an error and it is our error type
-			if (err && errors.isServerError(err, req.params.version)) {
+			if (err && errors.isServerError(err, req.params.base)) {
 				res.status(err.statusCode).json(err);
 			}
 			// If there is still an error, throw a 500 and pass the message through
 			else if (err) {
-				let error = errors.internal(err.message, req.params.version);
+				let error = errors.internal(err.message, req.params.base);
 				this.logger.error(error.statusCode, err.message);
 				res.status(error.statusCode).json(error);
 			}
@@ -191,7 +191,7 @@ class Server {
 
 		// Nothing has responded by now, respond with 404
 		this.app.use((req, res) => {
-			let error = errors.notFound(req.params.version);
+			let error = errors.notFound(req.params.base);
 			this.logger.error(error.statusCode, req.path);
 			res.status(error.statusCode).json(error);
 		});

--- a/src/server/utils/auth.js
+++ b/src/server/utils/auth.js
@@ -157,7 +157,7 @@ module.exports.validate = (allowedScopes, logger, config) => {
 					// get client
 					let [clientErr, client] = await handler(service.getClient(decodedToken.payload.aud));
 					if (clientErr) {
-						return next(errors.unauthorized(clientErr.message, req.params.version));
+						return next(errors.unauthorized(clientErr.message, req.params.base));
 
 					}
 
@@ -167,7 +167,7 @@ module.exports.validate = (allowedScopes, logger, config) => {
 						let [error, token] = await handler(verifyToken(decodedToken, bearerToken, client, config.auth.resourceServer));
 						if (error) {
 							logger.error(error);
-							return next(errors.unauthorized('', req.params.version));
+							return next(errors.unauthorized('', req.params.base));
 						}
 						validToken = token;
 
@@ -178,7 +178,7 @@ module.exports.validate = (allowedScopes, logger, config) => {
 							let [ introspectionError, introspection ] = await handler(introspect(bearerToken, config));
 							if (introspectionError) {
 								logger.error(introspectionError);
-								return next(errors.unauthorized('', req.params.version));
+								return next(errors.unauthorized('', req.params.base));
 							}
 							validToken = introspection;
 						}
@@ -209,18 +209,18 @@ module.exports.validate = (allowedScopes, logger, config) => {
 						// validation complete
 						return next();
 					} else {
-						return next(errors.unauthorized('Invalid token', req.params.version));
+						return next(errors.unauthorized('Invalid token', req.params.base));
 					}
 				} else {
 					// invalid bearer token
-					return next(errors.unauthorized('Invalid token', req.params.version));
+					return next(errors.unauthorized('Invalid token', req.params.base));
 				}
 
 
 			} else {
 				// did not pass checks, return 401 message
 				logger.error('Could not find bearer token in request headers');
-				return next(errors.unauthorized('Invalid token', req.params.version));
+				return next(errors.unauthorized('Invalid token', req.params.base));
 			}
 	};
 };

--- a/src/server/utils/auth.openid.validator.js
+++ b/src/server/utils/auth.openid.validator.js
@@ -58,7 +58,7 @@ function getValidScopes(scopes, allowedScopes) {
 module.exports.validate = (allowedScopes, logger, config) => {
 
 	return async (req, res, next) => {
-		let version = req.params.version;
+		let version = req.params.base;
 
 		// get bearer token
 		const bearerToken = parseBearerToken(req);

--- a/src/server/utils/conformance.utils.js
+++ b/src/server/utils/conformance.utils.js
@@ -16,10 +16,10 @@ let conformanceSearchParamsReduce = (collection, route_arg) => {
 * @description Filter function for determining which searchParam fields are needed
 * for conformance/capability statements
 * @param {Object} route_arg - route argument
-* @param {string} version - which version (not necessary now, but may be in the future)
+* @param {string} base - which version (not necessary now, but may be in the future)
 * @return {function} filter function for array.filter
 */
-let conformanceSearchParamsFilter = (version) => (route_arg) => {
+let conformanceSearchParamsFilter = (base) => (route_arg) => {
 	return route_arg.conformance_hide
 		// If the conformance_hide property is true, always remove this element
 		? false
@@ -28,7 +28,7 @@ let conformanceSearchParamsFilter = (version) => (route_arg) => {
 			// If no versions are provided, it is available for all versions
 			!route_arg.versions
 			// If versions are provided, make sure this arg is meant for this version
-			|| (route_arg.versions && route_arg.versions.indexOf(version) > -1)
+			|| (route_arg.versions && route_arg.versions.indexOf(base) > -1)
 		);
 };
 

--- a/src/server/utils/error.utils.js
+++ b/src/server/utils/error.utils.js
@@ -2,10 +2,10 @@ const { resolveFromVersion } = require('./resolve.utils');
 const { ISSUE, VERSIONS } = require('../../constants');
 
 // Helper to determine which operation outcome to retrieve
-let getErrorConstructor = version => {
-	switch (version) {
+let getErrorConstructor = base => {
+	switch (base) {
 		case VERSIONS.STU3:
-			return require(resolveFromVersion(version, 'uscore/OperationOutcome'));
+			return require(resolveFromVersion(base, 'uscore/OperationOutcome'));
 		default:
 			return require(resolveFromVersion(VERSIONS.STU3, 'uscore/OperationOutcome'));
 	}
@@ -19,8 +19,8 @@ let div_content = (severity, diagnostics) =>
 /* eslint-enable no-useless-escape */
 
 // Invalid or Missing parameter from request
-let invalidParameter = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let invalidParameter = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 400,
 		text: {
@@ -36,8 +36,8 @@ let invalidParameter = (message, version) => {
 };
 
 // Unauthorized request of some resource
-let unauthorized = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let unauthorized = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 401,
 		text: {
@@ -52,8 +52,8 @@ let unauthorized = (message, version) => {
 	});
 };
 
-let insufficientScope = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let insufficientScope = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 403,
 		text: {
@@ -68,8 +68,8 @@ let insufficientScope = (message, version) => {
 	});
 };
 
-let notFound = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let notFound = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 404,
 		text: {
@@ -84,8 +84,8 @@ let notFound = (message, version) => {
 	});
 };
 
-let methodNotAllowed = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let methodNotAllowed = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 405,
 		text: {
@@ -100,8 +100,8 @@ let methodNotAllowed = (message, version) => {
 	});
 };
 
-let deleteConflict = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let deleteConflict = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 409,
 		text: {
@@ -116,8 +116,8 @@ let deleteConflict = (message, version) => {
 	});
 };
 
-let deleted = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let deleted = (message, base) => {
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 410,
 		text: {
@@ -132,8 +132,9 @@ let deleted = (message, version) => {
 	});
 };
 
-let internal = (message, version) => {
-	let ErrorConstructor = getErrorConstructor(version);
+let internal = (message, base) => {
+	console.log('ERROR', message);
+	let ErrorConstructor = getErrorConstructor(base);
 	return new ErrorConstructor({
 		statusCode: 500,
 		text: {
@@ -148,7 +149,7 @@ let internal = (message, version) => {
 	});
 };
 
-let isServerError = (err, version) => err instanceof getErrorConstructor(version);
+let isServerError = (err, base) => err instanceof getErrorConstructor(base);
 
 /**
  * @name exports

--- a/src/server/utils/response.utils.js
+++ b/src/server/utils/response.utils.js
@@ -7,15 +7,15 @@ const errors = require('./error.utils');
 * @function handleSingleReadResponse
 * @param {Express.response} res - Express response object
 * @param {function} next - next function from express middleware
-* @param {string} version - Which spec version is this request coming from
+* @param {string} base - Which spec version is this request coming from
 * @param {T} Resource - Resource class to use for the results
 * @param {object} resource_json - resulting json to be passed in to the class
 */
-let handleSingleReadResponse = (res, next, version, Resource, resource_json) => {
+let handleSingleReadResponse = (res, next, base, Resource, resource_json) => {
 	if (resource_json) {
 		res.status(200).json(new Resource(resource_json));
 	} else {
-		next(errors.notFound(`${Resource.__resourceType} not found.`, version));
+		next(errors.notFound(`${Resource.__resourceType} not found.`, base));
 	}
 };
 
@@ -24,7 +24,7 @@ let handleSingleReadResponse = (res, next, version, Resource, resource_json) => 
 * they all need to respond in a similar manner
 * @function handleBundleReadResponse
 * @param {Express.response} res - Express response object
-* @param {string} version - Which spec version is this request coming from
+* @param {string} base - Which spec version is this request coming from
 * @param {T} Resource - Resource class to use for the results
 * @param {Array<object>} resource_json - resulting json to be passed in to the class
 * @param {object} options - Any additional options for configuring the response
@@ -36,8 +36,8 @@ let handleSingleReadResponse = (res, next, version, Resource, resource_json) => 
 * @param {function} options.filter - Filter function to filter the resources out
 * the filter function should expect a resource to be passed in and return a boolean
 */
-let handleBundleReadResponse = (res, version, Resource, resource_json = [], options) => {
-	let Bundle = require(resolveFromVersion(version, 'uscore/Bundle'));
+let handleBundleReadResponse = (res, base, Resource, resource_json = [], options) => {
+	let Bundle = require(resolveFromVersion(base, 'uscore/Bundle'));
 	let { filter, resourceUrl, resourceType = Resource.__resourceType } = options;
 	let results = new Bundle({ type: 'searchset' });
 	let entries = [];
@@ -52,7 +52,7 @@ let handleBundleReadResponse = (res, version, Resource, resource_json = [], opti
 				entries.push({
 					search: { mode: 'match' },
 					resource: new Resource(resource),
-					fullUrl: `${resourceUrl}/${version}/${resourceType}/${resource.id}`
+					fullUrl: `${resourceUrl}/${base}/${resourceType}/${resource.id}`
 				});
 			}
 		}
@@ -69,20 +69,20 @@ let handleBundleReadResponse = (res, version, Resource, resource_json = [], opti
 * they all need to respond in a similar manner with similar headers
 * @function handleCreateResponse
 * @param {Express.response} res - Express response object
-* @param {string} version - Which spec version is this request coming from
+* @param {string} base - Which spec version is this request coming from
 * @param {string} type - type of resource, e.g. Patient or Observation
 * @param {object} results - Results from the operation
 * @param {string} results.id - Id of the updated/created resource
-* @param {string} results.version - Version number of the updated resource
+* @param {string} results.resource_version - Version number of the updated resource
 */
-let handleCreateResponse = (res, version, type, results) => {
-	let { id, version: resource_version } = results;
+let handleCreateResponse = (res, base, type, results) => {
+	let { id, resource_version } = results;
 
 	if (resource_version) {
-		res.set('Content-Location', `${version}/${type}/${id}/_history/${resource_version}`);
+		res.set('Content-Location', `${base}/${type}/${id}/_history/${resource_version}`);
 	}
 
-	res.set('Location', `${version}/${type}/${id}`);
+	res.set('Location', `${base}/${type}/${id}`);
 	res.status(201).end();
 };
 
@@ -91,23 +91,23 @@ let handleCreateResponse = (res, version, type, results) => {
 * they all need to respond in a similar manner with similar headers
 * @function handleUpdateResponse
 * @param {Express.response} res - Express response object
-* @param {string} version - Which spec version is this request coming from
+* @param {string} base - Which spec version is this request coming from
 * @param {string} type - type of resource, e.g. Patient or Observation
 * @param {object} results - Results from the operation
 * @param {string} results.id - Id of the updated/created resource
 * @param {boolean} results.created - Did the update result in a new resource being created
-* @param {string} results.version - Version number of the updated resource
+* @param {string} results.resource_version - Version number of the updated resource
 */
-let handleUpdateResponse = (res, version, type, results) => {
-	let { id, created = false, version: resource_version } = results;
+let handleUpdateResponse = (res, base, type, results) => {
+	let { id, created = false, resource_version } = results;
 	let status = created ? 201 : 200;
 	let date = new Date();
 
 	if (resource_version) {
-		res.set('Content-Location', `${version}/${type}/${id}/_history/${resource_version}`);
+		res.set('Content-Location', `${base}/${type}/${id}/_history/${resource_version}`);
 	}
 
-	res.set('Location', `${version}/${type}/${id}`);
+	res.set('Location', `${base}/${type}/${id}`);
 	res.set('Last-Modified', date.toISOString());
 	res.status(status).end();
 };
@@ -128,7 +128,7 @@ let handleDeleteResponse = (res) => {
 * @function handleUpdateResponse
 * @param {Express.response} res - Express response object
 */
-let handleDeleteRejection = (res, next, version, err) => {
+let handleDeleteRejection = (res, next, base, err) => {
 	// Make sure the error code is valid
 	if (err.code !== 405 && err.code !== 409) {
 		let error = new Error('Invalid response code. Expected service to return an error code of either 405 or 409.');
@@ -136,8 +136,8 @@ let handleDeleteRejection = (res, next, version, err) => {
 	}
 	// pass the error through
 	let error = err.code === 405
-		? errors.methodNotAllowed(err.message, version)
-		: errors.deleteConflict(err.message, version);
+		? errors.methodNotAllowed(err.message, base)
+		: errors.deleteConflict(err.message, base);
 
 	next(error);
 };

--- a/src/server/utils/sanitize.utils.js
+++ b/src/server/utils/sanitize.utils.js
@@ -107,7 +107,7 @@ let sanitizeMiddleware = function (config) {
 
 			// If the argument is required but not present
 			if (!value && conf.required) {
-				return next(errors.invalidParameter(conf.name + ' is required', req.params.version));
+				return next(errors.invalidParameter(conf.name + ' is required', req.params.base));
 			}
 
 			// Try to cast the type to the correct type, do this first so that if something
@@ -117,12 +117,12 @@ let sanitizeMiddleware = function (config) {
 					cleanArgs[field] = parseValue(conf.type, value);
 				}
 			} catch (err) {
-				return next(errors.invalidParameter(conf.name + ' is invalid', req.params.version));
+				return next(errors.invalidParameter(conf.name + ' is invalid', req.params.base));
 			}
 
       // If we have the arg and the type is wrong, throw invalid arg
 			if (cleanArgs[field] !== undefined && !validateType(conf.type, cleanArgs[field])) {
-				return next(errors.invalidParameter('Invalid parameter: ' + conf.name, req.params.version));
+				return next(errors.invalidParameter('Invalid parameter: ' + conf.name, req.params.base));
 			}
 		}
 

--- a/src/server/utils/version.validation.utils.js
+++ b/src/server/utils/version.validation.utils.js
@@ -11,9 +11,9 @@ let versionValidationMiddleware = ( profile = {}) => {
 	let { versions = [] } = profile;
 
 	return function validationMiddleware (req, res, next) {
-		let request_version = req.params && req.params.version;
+		let base = req.params && req.params.base;
 
-		if (!request_version || versions.indexOf(request_version) === -1) {
+		if (!base || versions.indexOf(base) === -1) {
 			return next(errors.notFound());
 		}
 


### PR DESCRIPTION
Renamed the route parameter from version to base. In the FHIR specification it is referred to as base and after doing a walkthrough with JT and Jon Park we realized how easy it is to get confused between arguments and return props.

For example, in a `create` endpoint, you received `version` as an argument and have to return `version` to core when your done creating a resource. Version coming in was the FHIR version while version coming back was the resource version.

The update changes it so `base` comes in that is the version you should use, while `resource_version` is what the endpoint needs to return to core after creating a resource. These have already been documented in the wiki so all docs are up to date.