### PR TITLE
Ability to override the default capability statement generation

### DIFF
--- a/src/server/metadata/metadata.service.js
+++ b/src/server/metadata/metadata.service.js
@@ -42,7 +42,9 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	}).filter(profile => profile.versions.indexOf(context.base_version) !== -1);
 
 	// Get the necessary functions to generate statements
-	let { makeStatement, securityStatement } = getStatementGenerators(args.base_version);
+	let { makeStatement, securityStatement } = config.statementGenerator ?
+		config.statementGenerator(args, logger) :
+		getStatementGenerators(args.base_version);
 
 	// If we do not have these functions, we cannot generate a new statement
 	if (!makeStatement || !securityStatement) {

--- a/src/server/metadata/metadata.service.js
+++ b/src/server/metadata/metadata.service.js
@@ -28,7 +28,6 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	// Create a context object to pass through to underlying services
 	// we may add more information to this later on
 	let context = { base_version: args.base_version };
-
 	// create profile list
 	let keys = Object.keys(profiles);
 	let active_profiles = keys.map((profile_name) => {
@@ -64,7 +63,7 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	// Make the resource and give it the version so it can only include valid search params
 	server_statement.resource = active_profiles.map((profile) => {
 		let resource = profile.service.makeResource ?
-			profile.service.makeResource(context.base_version, profile.key) :
+			profile.service.makeResource(Object.assign(args, {'key': profile.key}), logger) :
 			profile.makeResource(context.base_version, profile.key);
 		// Determine the interactions we need to list for this profile
 		resource.interaction = generateInteractions(profile.service, resource.type);

--- a/src/server/metadata/metadata.service.js
+++ b/src/server/metadata/metadata.service.js
@@ -63,7 +63,9 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 
 	// Make the resource and give it the version so it can only include valid search params
 	server_statement.resource = active_profiles.map((profile) => {
-		let resource = profile.makeResource(context.base_version, profile.key, 'Patient');
+		let resource = profile.service.makeResource ?
+			profile.service.makeResource(context.base_version, profile.key) :
+			profile.makeResource(context.base_version, profile.key);
 		// Determine the interactions we need to list for this profile
 		resource.interaction = generateInteractions(profile.service, resource.type);
 		return resource;

--- a/src/server/metadata/metadata.test.js
+++ b/src/server/metadata/metadata.test.js
@@ -11,14 +11,14 @@ let server;
 let fillRoute = (route, key) => route.replace(':base_version', VERSIONS['3_0_1']).replace(':id', 1).replace(':resource', key);
 
 //A function to make a custom confirmance statement
-let customMakeResource = (base_version, key) => {
-    let Resource = require(resolve_utils.resolveFromVersion(base_version, key));
+let customMakeResource = (args,logger) => {
+    let Resource = require(resolve_utils.resolveFromVersion(args.base_version, args.key));
   
     // Return our conformance statement
     return {
       type: Resource.__resourceType,
       profile: {
-        reference: `http://example.org/fhir/${key}.html`
+        reference: `http://example.org/fhir/${args.key}.html`
       },
       conditionalDelete: 'not-supported',
       searchParam:  [

--- a/src/server/metadata/metadata.test.js
+++ b/src/server/metadata/metadata.test.js
@@ -1,0 +1,83 @@
+/* eslint-disable */
+
+const test_config = require('../../test.config');
+const { VERSIONS } = require('../../constants');
+const request = require('supertest');
+const Server = require('../server');
+const resolve_utils = require('../utils/resolve.utils');
+let server;
+
+// Helper function to replace express params with mock values
+let fillRoute = (route, key) => route.replace(':base_version', VERSIONS['3_0_1']).replace(':id', 1).replace(':resource', key);
+
+//A function to make a custom confirmance statement
+let customMakeResource = (base_version, key) => {
+    let Resource = require(resolve_utils.resolveFromVersion(base_version, key));
+  
+    // Return our conformance statement
+    return {
+      type: Resource.__resourceType,
+      profile: {
+        reference: `http://example.org/fhir/${key}.html`
+      },
+      conditionalDelete: 'not-supported',
+      searchParam:  [
+        {
+          "name": "_id",
+          "type": "token",
+          "documentation": "The ID of the resource"
+        }]
+    };
+}	
+
+describe('Conformance Tests', () => {
+
+	test('Test that every profile gets a default resource entry ', async () => {
+
+		// Standup a basic server
+		let config = Object.assign({}, test_config, { logging: { level: 'emerg' }});
+		server = new Server(config)
+			.setProfileRoutes()
+			.setErrorRoutes();
+
+        let keys = Object.keys(server.config.profiles);
+		let { routes } = require('../route.config');
+
+
+        let response = await request(server.app)['get']('/3_0_1/metadata');
+        expect(response.body.resourceType).toBe("CapabilityStatement");
+        //Check that the reference for each resource is the default
+		for (let key of keys) {
+            let account_resource = response.body.rest[0].resource.find( rsc => rsc.type === key);
+            expect(account_resource.profile.reference).toBe(`http://hl7.org/fhir/${key}.html`);
+		}
+	}, 60000);
+
+	test('Test that every profile gets a custom resource entry ', async () => {
+
+        //Add a custom make resource to the test services
+        let mock_service = require('../profiles/service.mock.js');  
+        mock_service.makeResource = customMakeResource;
+        // Standup a basic server
+		let config = Object.assign({}, test_config, { logging: { level: 'emerg' }});
+		server = new Server(config)
+			.setProfileRoutes()
+			.setErrorRoutes();
+
+        let keys = Object.keys(server.config.profiles);
+		let { routes } = require('../route.config');
+
+        //Patch the test config to include our custom makeResource
+		for (let key of keys) {
+            server.config.profiles[key].service = mock_service;
+        }
+        let response = await request(server.app)['get']('/3_0_1/metadata');
+        expect(response.body.resourceType).toBe("CapabilityStatement");
+        //Check the reference for each resource is the customised one
+		for (let key of keys) {
+            let account_resource = response.body.rest[0].resource.find( rsc => rsc.type === key);
+            expect(account_resource.profile.reference).toBe(`http://example.org/fhir/${key}.html`);
+		}
+	}, 60000);
+
+});


### PR DESCRIPTION
Introduces an optional config setting and an additional optional method on a profile service to allow a custom capability statement to be produced. It allows profiled/extended resources to be represented in the capability statement and for details such as server description to be changed without modifying the core library.

If a profile service provides a method called makeResource it will be used in place of the conformanceTemplate in the core library. The makeResource method accepts 2 parameters: args and logger and should return the conformance for the specific resource.

When given, the configuration option statementGenerator provides a method to be used in place of the getStatementGenerators function in the core metadata.service. The method provided by statementGenerator accepts 2 parameters: args and logger and should return an object/module with the same exports as the core capability.3_0_1.js module.

Examples of the use of both can been seen in the test suite metadata.test.js.
