### PR TITLE
Fix bug where argument filenames come as lowercased profileKey 

### DIFF
--- a/src/server/utils/params.utils.js
+++ b/src/server/utils/params.utils.js
@@ -1,30 +1,58 @@
-const { route_args, common_args, search_args } = require('../profiles/common.arguments');
+const path = require('path');
+const fs = require('fs');
 
-let common_args_array = Object.getOwnPropertyNames(common_args)
-	.map((arg_name) => common_args[arg_name]);
+const {
+	route_args,
+	common_args,
+	search_args
+} = require('../profiles/common.arguments');
+
+let common_args_array = Object.getOwnPropertyNames(common_args).map(
+	arg_name => common_args[arg_name]
+);
 
 /**
-* @description Middleware for validating the correct spec version is being accessed
-* If the user is trying to access R4 but the server is route is only supposed
-* to allow STU3, then we need to trigger a 404 error. Otherwise, we can continue.
-* @param {Object} profile - Configurations for the profile from the wrapping library
-* @return {function} valid express middleware
-*/
-let getSearchParamaters = ( profileKey, version ) => {
-	const resource_specific_args = require(`../standards/${version}/arguments/${profileKey}.arguments`);
+ * @description Middleware for validating the correct spec version is being accessed
+ * If the user is trying to access R4 but the server is route is only supposed
+ * to allow STU3, then we need to trigger a 404 error. Otherwise, we can continue.
+ * @param {Object} profile - Configurations for the profile from the wrapping library
+ * @return {function} valid express middleware
+ */
+let getSearchParamaters = (profileKey, version) => {
+	let fileIndex;
+	let files;
+	if (profileKey && typeof profileKey === 'string') {
+		files = fs
+			.readdirSync(
+				path.resolve(__dirname + `/../standards/${version}/arguments/`)
+			)
+			.map(filename => {
+				return filename;
+			});
 
+		const filesLowerCase = files.map(elm => elm.split('.')[0].toLowerCase());
+		fileIndex = filesLowerCase.indexOf(profileKey);
+	}
+
+	const resource_specific_args = require(`../standards/${version}/arguments/${
+		files[fileIndex] ? files[fileIndex] : profileKey + '.arguments'
+	}`);
 	// Set paramaters
-	let resource_args_array = Object.getOwnPropertyNames(resource_specific_args)
-		.map((arg_name) => Object.assign({ versions: version }, resource_specific_args[arg_name]));
+	let resource_args_array = Object.getOwnPropertyNames(
+		resource_specific_args
+	).map(arg_name =>
+		Object.assign({ versions: version }, resource_specific_args[arg_name])
+	);
 
-	let search_args_array = Object.getOwnPropertyNames(search_args)
-		.map((arg_name) => Object.assign({ versions: version }, search_args[arg_name]));
+	let search_args_array = Object.getOwnPropertyNames(search_args).map(
+		arg_name => Object.assign({ versions: version }, search_args[arg_name])
+	);
 
 	let resource_all_arguments = [
 		route_args.BASE,
 		...search_args_array,
 		...common_args_array,
-		...resource_args_array,
+		...resource_args_array
 	];
 
 	return resource_all_arguments;


### PR DESCRIPTION
Issue is trying to start server.  I pushed up the version to our jenkins/cloudfoundry handle which creates a container using ubuntu 16.04.  Filenames are case sensitive.  

```
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR Error: Cannot find module '../standards/3_0_1/arguments/allergyintolerance.arguments'
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     ^
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at configureResourceRoutes (/home/vcap/deps/0/node_modules/@asymmetrik/node-fhir-server-core/src/server/route-setter.js:151:20)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at Object.setter [as setRoutes] (/home/vcap/deps/0/node_modules/@asymmetrik/node-fhir-server-core/src/server/route-setter.js:278:2)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at getSearchParamaters (/home/vcap/deps/0/node_modules/@asymmetrik/node-fhir-server-core/src/server/utils/params.utils.js:23:33)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at Function.Module._resolveFilename (module.js:547:15)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at Function.Module._load (module.js:474:25)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at require (internal/module.js:11:18)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at Array.forEach (<anonymous>)
2018-10-11T14:16:08.74-0400 [APP/PROC/WEB/0] ERR     at profile.versions.forEach.version (/home/vcap/deps/0/node_modules/@asymmetrik/node-fhir-server-core/src/server/route-setter.js:152:30)
2018-10-11T14:16:08.75-0400 [APP/PROC/WEB/0] ERR npm ERR! code ELIFECYCLE
2018-10-11T14:16:08.75-0400 [APP/PROC/WEB/0] ERR npm ERR! Exit status 1
2018-10-11T14:16:08.75-0400 [APP/PROC/WEB/0] ERR npm ERR! fdb-proxy@0.0.1 start: `node server.js`
2018-10-11T14:16:08.75-0400 [APP/PROC/WEB/0] ERR npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
2018-10-11T14:16:08.75-0400 [APP/PROC/WEB/0] ERR npm ERR! Failed at the fdb-proxy@0.0.1 start script.
2018-10-11T14:16:08.83-0400 [APP/PROC/WEB/0] ERR npm ERR!     /home/vcap/app/.npm/_logs/2018-10-11T18_16_08_760Z-debug.log
2018-10-11T14:16:08.83-0400 [APP/PROC/WEB/0] ERR npm ERR! A complete log of this run can be found in:
```

I'm using Ubuntu 16.04.  File names are case sensitive.  

old code will resolve to 

`../standards/3_0_1/arguments/medication.arguments.js`

New code will resolve to 

`../standards/3_0_1/arguments/Medication.arguments.js` 

I am using my fork using this fix until we decide on the best way to handle this.

