### PR TITLE
default npm start as production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=8.6"
 	},
 	"scripts": {
-		"start": "cross-env NODE_ENV=production; node src/runner",
+		"start": "node src/runner",
 		"nodemon": "cross-env NODE_ENV=development; node src/scripts/nodemon",
 		"serve-docs": "npm run build-docs;node docs/server",
 		"build-docs": "cross-env NODE_ENV=production;node docs/build",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -93,7 +93,7 @@ class Server {
 		let { server = {}} = this.config;
 
 		this.env = {
-			IS_PRODUCTION: process.env.NODE_ENV === 'production',
+			IS_PRODUCTION: !process.env.NODE_ENV || process.env.NODE_ENV === 'production',
 			USE_HTTPS: server.ssl && server.ssl.key && server.ssl.cert
 		};
 		// return self for chaining


### PR DESCRIPTION
If no NODE_ENV, then treat as production