### PR TITLE
Feature/operations

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -179,7 +179,9 @@ exports.INTERACTIONS = {
 	CREATE: 'create',
 	UPDATE: 'update',
 	DELETE: 'remove',
-	EXPAND_BY_ID: 'expandById'
+	EXPAND_BY_ID: 'expandById',
+	OPERATIONS_POST: 'operationsPost',
+	OPERATIONS_GET: 'operationsGet'
 };
 
 /**

--- a/src/server/metadata/metadata.service.js
+++ b/src/server/metadata/metadata.service.js
@@ -30,6 +30,7 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	let context = { base_version: args.base_version };
 	// create profile list
 	let keys = Object.keys(profiles);
+	debugger
 	let active_profiles = keys.map((profile_name) => {
 		return {
 			key: profile_name,
@@ -45,7 +46,7 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 	let { makeStatement, securityStatement } = config.statementGenerator ?
 		config.statementGenerator(args, logger) :
 		getStatementGenerators(args.base_version);
-
+	debugger
 	// If we do not have these functions, we cannot generate a new statement
 	if (!makeStatement || !securityStatement) {
 		// TODO: Figure out messaging for this scenario
@@ -68,6 +69,7 @@ let generateCapabilityStatement = (args, config, logger) => new Promise((resolve
 			profile.service.makeResource(Object.assign(args, {'key': profile.key}), logger) :
 			profile.makeResource(context.base_version, profile.key);
 		// Determine the interactions we need to list for this profile
+		debugger
 		resource.interaction = generateInteractions(profile.service, resource.type);
 		return resource;
 	});

--- a/src/server/operations/operations.controller.js
+++ b/src/server/operations/operations.controller.js
@@ -1,0 +1,46 @@
+const responseUtils = require('../utils/response.utils');
+const errors = require('../utils/error.utils');
+
+
+/**
+ * @description Controller for all POST operations
+ */
+module.exports.operationsPost = function operationsPost({profile, logger, funcName}) {
+  let {serviceModule: service} = profile;
+
+  return (req, res, next) => {
+    let { base_version, resource_id} = req.sanitized_args;
+    let resource_body = req.body;
+    let args = {id: resource_id, base_version, resource: resource_body};
+
+    service[funcName](args, req.contexts, logger)
+      .then(results => {
+        responseUtils.handleOperationResponse(res, next, base_version, results);
+      })
+      .catch(err => {
+        logger.error(err);
+				next(errors.internal(err.message, base_version));
+      });
+  };
+};
+
+
+/**
+ * @description Controller for all GET operations
+ */
+module.exports.operationsGet = function operationsGet({profile, logger, funcName}) {
+  let {serviceModule: service} = profile;
+  return (req, res, next) => {
+    let { base_version, resource_id} = req.sanitized_args;
+    let resource_body = req.body;
+    let args = {id: resource_id, base_version, resource: resource_body};
+    service[funcName](args, req.contexts, logger)
+      .then(results => {
+        responseUtils.handleOperationResponse(res, next, base_version, results);
+      })
+      .catch(err => {
+        logger.error(err);
+        next(errors.internal(err.message, base_version));
+      });
+  };
+};

--- a/src/server/route-setter.js
+++ b/src/server/route-setter.js
@@ -94,10 +94,11 @@ function hasValidScopes(options) {
 }
 
 function configureMetadataRoute(options) {
+	console.log('boot')
 	let { app, config, logger } = options;
 	let { profiles, server } = config;
 	let { route } = require('./metadata/metadata.config');
-
+	debugger
 	// The user can provider default cors options to be provided on all routes
 	let default_cors_options = Object.assign({}, server.corsOptions);
 	let profile = { versions: getAllConfiguredVersions(profiles) };

--- a/src/server/route.config.js
+++ b/src/server/route.config.js
@@ -53,6 +53,16 @@ let routes = [
 		interaction: INTERACTIONS.EXPAND_BY_ID
 	},
 	/* eslint-disable no-useless-escape */
+	{
+		type: 'post',
+		path: '/:base_version/:resource',
+		interaction: INTERACTIONS.OPERATIONS_POST
+	},
+	{
+		type: 'get',
+		path: '/:base_version/:resource',
+		interaction: INTERACTIONS.OPERATIONS_GET
+	}
 ];
 
 /**

--- a/src/server/utils/hyphen-to-camel.utils.js
+++ b/src/server/utils/hyphen-to-camel.utils.js
@@ -1,0 +1,3 @@
+module.exports = (hyphenString) => {
+  return hyphenString.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+};

--- a/src/server/utils/response.utils.js
+++ b/src/server/utils/response.utils.js
@@ -45,6 +45,21 @@ let handleSingleReadResponse = (res, next, base_version, Resource, resource_json
 };
 
 /**
+ * @description Handle all Operation Responses by passing own resource, because all operations
+ * should return an out <Parameter>
+ * @function handleOperationResponse
+ * @param {Express.response} res - Express response object
+ * @param {function} next - next function from express middleware
+ * @param {string} base_version - Which spec version is this request coming from
+ * @param {object} resource_json - resulting json to be passed in to the class
+ */
+let handleOperationResponse = (res, next, base_version, resource_json) => {
+	//An Operation should always return some sort of out <Parameter>.
+	res.type(getContentType(base_version));
+	res.status(200).json(resource_json);
+};
+
+/**
  * @description When resources are read in the controller functions
  * they all need to respond in a similar manner
  * @function handleBundleReadResponse
@@ -276,11 +291,12 @@ let handleBundleHistoryResponse = (res, base_version, Resource, resource_json = 
  */
 module.exports = {
 	handleSingleReadResponse,
+	handleOperationResponse,
 	handleBundleReadResponse,
 	handleCreateResponse,
 	handleUpdateResponse,
 	handleDeleteResponse,
 	handleDeleteRejection,
 	handleBundleHistoryResponse,
-	handleExpandReadResponse
+	handleExpandReadResponse,
 };


### PR DESCRIPTION
Pull request for operations,  #102  .  I elected for config file to look like so.  

![screen shot 2018-12-11 at 10 23 36 am](https://user-images.githubusercontent.com/6124206/49810362-160c5f80-fd2f-11e8-91c2-89d56f07306c.png)

Required are name, route, and method. The build will fail if you do not include these and do include an operation.  You can hard code a reference if you'd like, as I do with patient, or you can leave blank and it will generate one for you.  This will generate a CapaabilityStatement like so (resources are closed but are there).

<img width="1100" alt="screen shot 2018-12-11 at 10 19 17 am" src="https://user-images.githubusercontent.com/6124206/49810136-88c90b00-fd2e-11e8-9f11-efbf6787bae2.png">

The meat of this is in the route setter.  I mostly copied how resource routes are set, but a few changes for operations of either GET or POST.  The main caveat is line 310, `route.path.replace(':resource', key).concat(op.route).replace('$', '([\\$])')` . Routes with a dollar sign, for express to work, need to have an escaped `$`.   

The user will then need to declare a function name equivalent to the name set in their config file, but camelcased.  The build will fail if it sees a name in the config file but does not see an equivalently named function in the user's implementation.  Below I show what mine looks like with name `duplicate-therapy`

![screen shot 2018-12-11 at 10 20 34 am](https://user-images.githubusercontent.com/6124206/49810192-aa29f700-fd2e-11e8-88f4-f6256e9e2e60.png)

The operation handler in `response.utils` is basically a pass through.  We leave it up to the user to format their responses.  

Finally, I show my results.  
<img width="1680" alt="screen shot 2018-12-11 at 10 20 33 am" src="https://user-images.githubusercontent.com/6124206/49810203-b2823200-fd2e-11e8-89d5-a723dc06bd76.png">

I am open to suggestions on how to improve this.  
