### PR TITLE
Added the 'part' attribute to the FHIR Parameters object

### DIFF
--- a/src/server/standards/3_0_1/Parameters.js
+++ b/src/server/standards/3_0_1/Parameters.js
@@ -28,8 +28,8 @@ class Parameters extends Resource {
 	}
 
 	set parameter (new_value) {
-		const ParametersParameter = require('./ParametersParameter');
-		this.__parameter = Array.isArray(new_value) ? new_value.map(val => new ParametersParameter(val)) : [new ParametersParameter(new_value)];
+		const ParametersParameterMultiPart = require('./ParametersParameterMultiPart');
+		this.__parameter = Array.isArray(new_value) ? new_value.map(val => new ParametersParameterMultiPart(val)) : [new ParametersParameterMultiPart(new_value)];
 	}
 
 	toJSON () {

--- a/src/server/standards/3_0_1/ParametersParameterMultiPart.js
+++ b/src/server/standards/3_0_1/ParametersParameterMultiPart.js
@@ -1,0 +1,33 @@
+const ParametersParameter = require('./ParametersParameter');
+
+class ParametersParameterMultiPart extends ParametersParameter {
+
+	constructor ( opt ) {
+		super( opt );
+		this.__resourceType = 'ParametersParameterMultiPart';
+		Object.assign(this, opt);
+	}
+
+	// This is a Parameters Parameter resource with a 'part' array describing
+	// multi-part parameters
+	static get __resourceType () {
+		return 'ParametersParameterMultiPart';
+	}
+
+	// A named part of a multi-part parameter..
+	get part () {
+		return this.__part;
+	}
+
+	set part (new_value) {
+		this.__part = Array.isArray(new_value) ? new_value.map(val => new ParametersParameter(val)) : [new ParametersParameter(new_value)];
+	}
+
+	toJSON () {
+		return Object.assign(super.toJSON(), {
+			part: this.__part && this.__part.map(v => v.toJSON())
+		});
+	}
+}
+
+module.exports = ParametersParameterMultiPart;


### PR DESCRIPTION
Added the 'part' attribute to the FHIR Parameters object. 'part' is a valid attribute of Parameter object for v3.0.1. Here is a screenshot of a valid response for a local project:

<img width="1406" alt="screen shot 2018-12-11 at 11 40 22 am" src="https://user-images.githubusercontent.com/10760045/49815365-9c2da380-fd39-11e8-9b23-5ca99319e6a7.png">

See this link for reference:
http://www.hl7.org/fhir/parameters-definitions.html#Parameters.parameter.part