### PR TITLE
Add ability to use third party error tracking software for expressjs

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -102,6 +102,10 @@ class Server {
 
 	// Configure middleware
 	configureMiddleware () {
+		//Enable error tracking request handler if supplied in config
+		if (this.config.errorTracking && this.config.errorTracking.requestHandler) {
+			this.app.use(this.config.errorTracking.requestHandler());
+		}
 		// Enable stack traces
 		this.app.set('showStackError', !this.env.IS_PRODUCTION);
 		// Add compression
@@ -183,6 +187,11 @@ class Server {
 
 	// Setup error routes
 	setErrorRoutes () {
+		//Enable error tracking error handler if supplied in config
+		if (this.config.errorTracking && this.config.errorTracking.errorHandler) {
+			this.app.use(this.config.errorTracking.errorHandler());
+		}
+
 		// Generic catch all error handler
 		// Errors should be thrown with next and passed through
 		this.app.use((err, req, res, next) => {


### PR DESCRIPTION
Added a config property that looks like so.  All error handlers (sentry, rollbar, etc.) need their error handler to be injected before all other error handling software.  This code sets it if supplied by the user.

```
	errorTracking: {
		requestHandler: Sentry.Handlers.requestHandler,
		errorHandler: Sentry.Handlers.errorHandler
	}
```

