### PR TITLE
Don’t override the methods if defined in the config

### DIFF
--- a/src/server/route-setter.js
+++ b/src/server/route-setter.js
@@ -218,7 +218,7 @@ function configureResourceRoutes(options) {
 				default_cors_options,
 				profile && profile.corsOptions,
 				// Add a default cors setting for methods that defaults to type, e.g. { methods: [ 'DELETE' ]}
-				{ methods: [route.type.toUpperCase()] },
+				{ methods: default_cors_options.methods || [route.type.toUpperCase()] },
 			);
 
 			// Enable cors with preflight options

--- a/src/test.config.js
+++ b/src/test.config.js
@@ -15,6 +15,7 @@ module.exports = {
 		port: 3000,
 		corsOptions: {
 			maxAge: 86400,
+			methods: 'HEAD,PUT,PATCH,POST,DELETE'
 		},
 		// ssl: {
 		// 	key: './src/key.pem',


### PR DESCRIPTION
Methods is overriding the cors.methods in the configuration.

since GET, PUT, DELETE all uses /:base/:resource/:id, cors options only gets the first one (GET).