### PR TITLE
Feature: Custom Error Implementation

### DIFF
--- a/src/server/operations/operations.controller.js
+++ b/src/server/operations/operations.controller.js
@@ -17,8 +17,7 @@ module.exports.operationsPost = function operationsPost({ profile, logger, funcN
 				responseUtils.handleOperationResponse(res, next, base_version, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -35,8 +34,7 @@ module.exports.operationsGet = function operationsGet({ profile, logger, funcNam
 				responseUtils.handleOperationResponse(res, next, base_version, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/account/account.controller.js
+++ b/src/server/profiles/account/account.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Account, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -68,8 +66,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 			.searchById(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Account, results))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -146,8 +142,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -191,8 +186,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -216,8 +210,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/activitydefinition/activitydefinition.controller.js
+++ b/src/server/profiles/activitydefinition/activitydefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ActivityDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ActivityDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/adverseevent/adverseevent.controller.js
+++ b/src/server/profiles/adverseevent/adverseevent.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, AdverseEvent, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, AdverseEvent, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, AllergyIntolerance, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, AllergyIntolerance, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/appointment/appointment.controller.js
+++ b/src/server/profiles/appointment/appointment.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Appointment, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Appointment, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
+++ b/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, AppointmentResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, AppointmentResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/auditevent/auditevent.controller.js
+++ b/src/server/profiles/auditevent/auditevent.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, AuditEvent, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, AuditEvent, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/basic/basic.controller.js
+++ b/src/server/profiles/basic/basic.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Basic, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Basic, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/binary/binary.controller.js
+++ b/src/server/profiles/binary/binary.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Binary, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Binary, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/bodysite/bodysite.controller.js
+++ b/src/server/profiles/bodysite/bodysite.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, BodySite, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, BodySite, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/bundle/bundle.controller.js
+++ b/src/server/profiles/bundle/bundle.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Bundle, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Bundle, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
+++ b/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, CapabilityStatement, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CapabilityStatement, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/careplan/careplan.controller.js
+++ b/src/server/profiles/careplan/careplan.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, CarePlan, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CarePlan, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/careteam/careteam.controller.js
+++ b/src/server/profiles/careteam/careteam.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, CareTeam, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CareTeam, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/chargeitem/chargeitem.controller.js
+++ b/src/server/profiles/chargeitem/chargeitem.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, ChargeItem, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ChargeItem, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/claim/claim.controller.js
+++ b/src/server/profiles/claim/claim.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Claim, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Claim, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/claimresponse/claimresponse.controller.js
+++ b/src/server/profiles/claimresponse/claimresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ClaimResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ClaimResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
+++ b/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ClinicalImpression, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ClinicalImpression, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/codesystem/codesystem.controller.js
+++ b/src/server/profiles/codesystem/codesystem.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, CodeSystem, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CodeSystem, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/communication/communication.controller.js
+++ b/src/server/profiles/communication/communication.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Communication, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Communication, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/communicationrequest/communicationrequest.controller.js
+++ b/src/server/profiles/communicationrequest/communicationrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, CommunicationRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CommunicationRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
+++ b/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, CompartmentDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, CompartmentDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/composition/composition.controller.js
+++ b/src/server/profiles/composition/composition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Composition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Composition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/conceptmap/conceptmap.controller.js
+++ b/src/server/profiles/conceptmap/conceptmap.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, ConceptMap, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ConceptMap, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/condition/condition.controller.js
+++ b/src/server/profiles/condition/condition.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Condition, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Condition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/consent/consent.controller.js
+++ b/src/server/profiles/consent/consent.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Consent, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Consent, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/contract/contract.controller.js
+++ b/src/server/profiles/contract/contract.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Contract, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Contract, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/coverage/coverage.controller.js
+++ b/src/server/profiles/coverage/coverage.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Coverage, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Coverage, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/dataelement/dataelement.controller.js
+++ b/src/server/profiles/dataelement/dataelement.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DataElement, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DataElement, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/detectedissue/detectedissue.controller.js
+++ b/src/server/profiles/detectedissue/detectedissue.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DetectedIssue, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DetectedIssue, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/device/device.controller.js
+++ b/src/server/profiles/device/device.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Device, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Device, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/devicecomponent/devicecomponent.controller.js
+++ b/src/server/profiles/devicecomponent/devicecomponent.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceComponent, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceComponent, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/devicemetric/devicemetric.controller.js
+++ b/src/server/profiles/devicemetric/devicemetric.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceMetric, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceMetric, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/devicerequest/devicerequest.controller.js
+++ b/src/server/profiles/devicerequest/devicerequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
+++ b/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceUseStatement, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DeviceUseStatement, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DiagnosticReport, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DiagnosticReport, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/documentmanifest/documentmanifest.controller.js
+++ b/src/server/profiles/documentmanifest/documentmanifest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DocumentManifest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DocumentManifest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/documentreference/documentreference.controller.js
+++ b/src/server/profiles/documentreference/documentreference.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, DocumentReference, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, DocumentReference, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
+++ b/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, EligibilityRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, EligibilityRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
+++ b/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, EligibilityResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, EligibilityResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/encounter/encounter.controller.js
+++ b/src/server/profiles/encounter/encounter.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Encounter, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Encounter, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/endpoint/endpoint.controller.js
+++ b/src/server/profiles/endpoint/endpoint.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Endpoint, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Endpoint, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
+++ b/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, EnrollmentRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, EnrollmentRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
+++ b/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, EnrollmentResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, EnrollmentResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/episodeofcare/episodeofcare.controller.js
+++ b/src/server/profiles/episodeofcare/episodeofcare.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, EpisodeOfCare, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, EpisodeOfCare, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/expansionprofile/expansionprofile.controller.js
+++ b/src/server/profiles/expansionprofile/expansionprofile.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ExpansionProfile, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ExpansionProfile, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
+++ b/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ExplanationOfBenefit, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ExplanationOfBenefit, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
+++ b/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, FamilyMemberHistory, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, FamilyMemberHistory, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/flag/flag.controller.js
+++ b/src/server/profiles/flag/flag.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Flag, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Flag, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -144,8 +140,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -189,8 +184,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -214,8 +208,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/goal/goal.controller.js
+++ b/src/server/profiles/goal/goal.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Goal, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Goal, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -144,8 +140,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -189,8 +184,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -214,8 +208,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/graphdefinition/graphdefinition.controller.js
+++ b/src/server/profiles/graphdefinition/graphdefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, GraphDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, GraphDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/group/group.controller.js
+++ b/src/server/profiles/group/group.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Group, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Group, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
+++ b/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, GuidanceResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, GuidanceResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/healthcareservice/healthcareservice.controller.js
+++ b/src/server/profiles/healthcareservice/healthcareservice.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, HealthcareService, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, HealthcareService, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
+++ b/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImagingManifest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImagingManifest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/imagingstudy/imagingstudy.controller.js
+++ b/src/server/profiles/imagingstudy/imagingstudy.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImagingStudy, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImagingStudy, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/immunization/immunization.controller.js
+++ b/src/server/profiles/immunization/immunization.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Immunization, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Immunization, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
+++ b/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
@@ -33,8 +33,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -57,8 +56,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -79,8 +77,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImmunizationRecommendation, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -118,8 +115,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -157,8 +153,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -202,8 +197,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -227,8 +221,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/implementationguide/implementationguide.controller.js
+++ b/src/server/profiles/implementationguide/implementationguide.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImplementationGuide, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ImplementationGuide, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/library/library.controller.js
+++ b/src/server/profiles/library/library.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Library, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Library, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/linkage/linkage.controller.js
+++ b/src/server/profiles/linkage/linkage.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Linkage, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Linkage, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/list/list.controller.js
+++ b/src/server/profiles/list/list.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, List, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, List, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -144,8 +140,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -189,8 +184,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -214,8 +208,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/location/location.controller.js
+++ b/src/server/profiles/location/location.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Location, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Location, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/measure/measure.controller.js
+++ b/src/server/profiles/measure/measure.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Measure, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Measure, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/measurereport/measurereport.controller.js
+++ b/src/server/profiles/measurereport/measurereport.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MeasureReport, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MeasureReport, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/media/media.controller.js
+++ b/src/server/profiles/media/media.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Media, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Media, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/medication/medication.controller.js
+++ b/src/server/profiles/medication/medication.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Medication, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Medication, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/medicationadministration/medicationadministration.controller.js
+++ b/src/server/profiles/medicationadministration/medicationadministration.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationAdministration, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationAdministration, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/medicationdispense/medicationdispense.controller.js
+++ b/src/server/profiles/medicationdispense/medicationdispense.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationDispense, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationDispense, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/medicationrequest/medicationrequest.controller.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/medicationstatement/medicationstatement.controller.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationStatement, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MedicationStatement, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/messagedefinition/messagedefinition.controller.js
+++ b/src/server/profiles/messagedefinition/messagedefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MessageDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MessageDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/messageheader/messageheader.controller.js
+++ b/src/server/profiles/messageheader/messageheader.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, MessageHeader, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, MessageHeader, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/namingsystem/namingsystem.controller.js
+++ b/src/server/profiles/namingsystem/namingsystem.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, NamingSystem, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, NamingSystem, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/nutritionorder/nutritionorder.controller.js
+++ b/src/server/profiles/nutritionorder/nutritionorder.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, NutritionOrder, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, NutritionOrder, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/observation/observation.controller.js
+++ b/src/server/profiles/observation/observation.controller.js
@@ -27,8 +27,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Observation, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -71,8 +70,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				res.status(200).json(results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -90,8 +88,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Observation, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -130,8 +127,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -171,8 +167,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -217,8 +212,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -242,8 +236,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/operationdefinition/operationdefinition.controller.js
+++ b/src/server/profiles/operationdefinition/operationdefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, OperationDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, OperationDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/organization/organization.controller.js
+++ b/src/server/profiles/organization/organization.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Organization, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Organization, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -113,8 +110,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -154,8 +150,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -199,8 +194,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -224,8 +218,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/patient/patient.controller.js
+++ b/src/server/profiles/patient/patient.controller.js
@@ -38,8 +38,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Patient, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -61,8 +60,7 @@ module.exports.search = function search({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -79,8 +77,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 			.searchById(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Patient, results))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -119,8 +116,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -160,8 +156,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -206,8 +201,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -231,8 +225,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -262,8 +255,7 @@ module.exports.patch = function patch({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/paymentnotice/paymentnotice.controller.js
+++ b/src/server/profiles/paymentnotice/paymentnotice.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, PaymentNotice, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, PaymentNotice, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
+++ b/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, PaymentReconciliation, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, PaymentReconciliation, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/person/person.controller.js
+++ b/src/server/profiles/person/person.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Person, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Person, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/plandefinition/plandefinition.controller.js
+++ b/src/server/profiles/plandefinition/plandefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, PlanDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, PlanDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/practitioner/practitioner.controller.js
+++ b/src/server/profiles/practitioner/practitioner.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Practitioner, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Practitioner, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/practitionerrole/practitionerrole.controller.js
+++ b/src/server/profiles/practitionerrole/practitionerrole.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, PractitionerRole, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, PractitionerRole, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/procedure/procedure.controller.js
+++ b/src/server/profiles/procedure/procedure.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Procedure, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Procedure, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/procedurerequest/procedurerequest.controller.js
+++ b/src/server/profiles/procedurerequest/procedurerequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcedureRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcedureRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/processrequest/processrequest.controller.js
+++ b/src/server/profiles/processrequest/processrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcessRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcessRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/processresponse/processresponse.controller.js
+++ b/src/server/profiles/processresponse/processresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcessResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ProcessResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/provenance/provenance.controller.js
+++ b/src/server/profiles/provenance/provenance.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Provenance, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Provenance, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/questionnaire/questionnaire.controller.js
+++ b/src/server/profiles/questionnaire/questionnaire.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Questionnaire, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Questionnaire, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
+++ b/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, QuestionnaireResponse, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, QuestionnaireResponse, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/referralrequest/referralrequest.controller.js
+++ b/src/server/profiles/referralrequest/referralrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ReferralRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ReferralRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/relatedperson/relatedperson.controller.js
+++ b/src/server/profiles/relatedperson/relatedperson.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, RelatedPerson, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, RelatedPerson, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/requestgroup/requestgroup.controller.js
+++ b/src/server/profiles/requestgroup/requestgroup.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, RequestGroup, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, RequestGroup, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/researchstudy/researchstudy.controller.js
+++ b/src/server/profiles/researchstudy/researchstudy.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ResearchStudy, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ResearchStudy, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/researchsubject/researchsubject.controller.js
+++ b/src/server/profiles/researchsubject/researchsubject.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ResearchSubject, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ResearchSubject, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/riskassessment/riskassessment.controller.js
+++ b/src/server/profiles/riskassessment/riskassessment.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, RiskAssessment, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, RiskAssessment, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/schedule/schedule.controller.js
+++ b/src/server/profiles/schedule/schedule.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Schedule, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Schedule, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/searchparameter/searchparameter.controller.js
+++ b/src/server/profiles/searchparameter/searchparameter.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, SearchParameter, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, SearchParameter, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/sequence/sequence.controller.js
+++ b/src/server/profiles/sequence/sequence.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Sequence, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Sequence, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/servicedefinition/servicedefinition.controller.js
+++ b/src/server/profiles/servicedefinition/servicedefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, ServiceDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ServiceDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/slot/slot.controller.js
+++ b/src/server/profiles/slot/slot.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Slot, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Slot, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -144,8 +140,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -189,8 +184,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -214,8 +208,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/specimen/specimen.controller.js
+++ b/src/server/profiles/specimen/specimen.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Specimen, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Specimen, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/structuredefinition/structuredefinition.controller.js
+++ b/src/server/profiles/structuredefinition/structuredefinition.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, StructureDefinition, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, StructureDefinition, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/structuremap/structuremap.controller.js
+++ b/src/server/profiles/structuremap/structuremap.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, StructureMap, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, StructureMap, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/subscription/subscription.controller.js
+++ b/src/server/profiles/subscription/subscription.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, Subscription, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Subscription, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/substance/substance.controller.js
+++ b/src/server/profiles/substance/substance.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Substance, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Substance, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/supplydelivery/supplydelivery.controller.js
+++ b/src/server/profiles/supplydelivery/supplydelivery.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, SupplyDelivery, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, SupplyDelivery, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/supplyrequest/supplyrequest.controller.js
+++ b/src/server/profiles/supplyrequest/supplyrequest.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, SupplyRequest, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, SupplyRequest, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/task/task.controller.js
+++ b/src/server/profiles/task/task.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, Task, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, Task, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -107,8 +104,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -144,8 +140,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -189,8 +184,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -214,8 +208,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/testreport/testreport.controller.js
+++ b/src/server/profiles/testreport/testreport.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, TestReport, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, TestReport, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/testscript/testscript.controller.js
+++ b/src/server/profiles/testscript/testscript.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, TestScript, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, TestScript, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/valueset/valueset.controller.js
+++ b/src/server/profiles/valueset/valueset.controller.js
@@ -24,8 +24,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 			.searchByVersionId(req.sanitized_args, req.contexts, logger)
 			.then(results => responseUtils.handleSingleReadResponse(res, next, base_version, ValueSet, results, version_id))
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -48,8 +47,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -70,8 +68,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, ValueSet, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -109,8 +106,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -148,8 +144,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -193,8 +188,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -218,8 +212,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -242,8 +235,7 @@ module.exports.expandById = function expandById({ profile, logger, config }) {
 				});
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/profiles/visionprescription/visionprescription.controller.js
+++ b/src/server/profiles/visionprescription/visionprescription.controller.js
@@ -26,8 +26,7 @@ module.exports.searchByVersionId = function searchByVersionId({ profile, logger,
 				responseUtils.handleSingleReadResponse(res, next, base_version, VisionPrescription, results, version_id),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -50,8 +49,7 @@ module.exports.search = function search({ profile, logger, config, app }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -72,8 +70,7 @@ module.exports.searchById = function searchById({ profile, logger, app }) {
 				responseUtils.handleSingleReadResponse(res, next, base_version, VisionPrescription, results);
 			})
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -111,8 +108,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -150,8 +146,7 @@ module.exports.update = function update({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -195,8 +190,7 @@ module.exports.history = function history({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };
@@ -220,8 +214,7 @@ module.exports.historyById = function historyById({ profile, logger, config }) {
 				}),
 			)
 			.catch(err => {
-				logger.error(err);
-				next(errors.internal(err.message, base_version));
+				next(errors.internal(err, base_version));
 			});
 	};
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -220,16 +220,19 @@ class Server {
 		this.app.use((err, req, res, next) => {
 			// get base from URL instead of params since it might not be forwarded
 			let base = req.url.split('/')[1];
-
+			// If implementer used custom error
+			if (err && err.isCustom) {
+				return res.status(err.statusCode).json(err);
+			}
 			// If there is an error and it is our error type
 			if (err && errorUtils.isServerError(err, base)) {
-				res.status(err.statusCode).json(err);
+				return res.status(err.statusCode).json(err);
 			}
 			// If there is still an error, throw a 500 and pass the message through
 			else if (err) {
 				let error = errorUtils.internal(err.message, base);
 				this.logger.error(error.statusCode, err);
-				res.status(error.statusCode).json(error);
+				return res.status(error.statusCode).json(error);
 			}
 			// No error
 			else {


### PR DESCRIPTION
A user can now reject errors in his/her implementation that are custom.  By toggling
`error.isCustom = true`, a user will need to set `statusCode`, `code`, `severity`, and `message`.

I had to change all controller actions from 
`next(errors.internal(err.message, base_version));` to 
`next(errors.internal(err, base_version));` passing the entire error object.  

The only real changes are at the very bottom... server/server.js, server/utils/error.utils.js, and server/utils/error.utils.test.js

Changed `internal` error test to show it in action

My implementation for generating a 404 error looks like so
`custom-error.js`
```js
const logger = require('./logger')

class ErrorNotFound extends Error {
  constructor(...params) {
    super(...params)

    if(Error.captureStackTrace) {
      Error.captureStackTrace(this,ErrorNotFound)
    }

    this.statusCode = 404
    this.severity = 'warning'
    this.code = 'not-found'
    this.isCustom = true

    logger.warn('Resource not found.')
  }
}

module.exports = ErrorNotFound
```

and `medication.js` searchById

```js
module.exports.searchById = (args, context, logger) => {
	logger.info(`Getting medication with ID: ${args.id}`)
	return new Promise(async (resolve, reject) => {
		try {
			let data = await getDispensableDrugById(args.id)
			if (data.statusCode === 404) {
				const notFound = new ErrorNotFound('Resource not found.')
				return reject(notFound)
			}
			
			const resp = JSON.parse(data.body)
			const convertedFhirMed = fhirMedicationObject(resp.DispensableDrug)
			resolve(convertedFhirMed)
		} catch (err) {
			reject(err)
		}
	})
```
