### PR TITLE
Rename __resourceType to resourceType in controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Node FHIR Rest API Server",
   "main": "src/index",
   "author": "Asymmetrik Ltd.",

--- a/src/server/profiles/account/account.controller.js
+++ b/src/server/profiles/account/account.controller.js
@@ -82,10 +82,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Account = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Account.__resourceType !== resource_body.resourceType) {
+		if (Account.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Account.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Account.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Account.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Account.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Account = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Account.__resourceType !== resource_body.resourceType) {
+		if (Account.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Account.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Account.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -137,7 +137,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Account.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Account.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/activitydefinition/activitydefinition.controller.js
+++ b/src/server/profiles/activitydefinition/activitydefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ActivityDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ActivityDefinition.__resourceType !== resource_body.resourceType) {
+		if (ActivityDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ActivityDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ActivityDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ActivityDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ActivityDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ActivityDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ActivityDefinition.__resourceType !== resource_body.resourceType) {
+		if (ActivityDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ActivityDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ActivityDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ActivityDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ActivityDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/adverseevent/adverseevent.controller.js
+++ b/src/server/profiles/adverseevent/adverseevent.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let AdverseEvent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AdverseEvent.__resourceType !== resource_body.resourceType) {
+		if (AdverseEvent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AdverseEvent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AdverseEvent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, AdverseEvent.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, AdverseEvent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let AdverseEvent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AdverseEvent.__resourceType !== resource_body.resourceType) {
+		if (AdverseEvent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AdverseEvent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AdverseEvent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, AdverseEvent.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, AdverseEvent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
+++ b/src/server/profiles/allergyintolerance/allergyintolerance.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let AllergyIntolerance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AllergyIntolerance.__resourceType !== resource_body.resourceType) {
+		if (AllergyIntolerance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AllergyIntolerance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AllergyIntolerance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, AllergyIntolerance.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, AllergyIntolerance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let AllergyIntolerance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AllergyIntolerance.__resourceType !== resource_body.resourceType) {
+		if (AllergyIntolerance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AllergyIntolerance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AllergyIntolerance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, AllergyIntolerance.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, AllergyIntolerance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/appointment/appointment.controller.js
+++ b/src/server/profiles/appointment/appointment.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Appointment = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Appointment.__resourceType !== resource_body.resourceType) {
+		if (Appointment.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Appointment.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Appointment.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Appointment.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Appointment.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Appointment = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Appointment.__resourceType !== resource_body.resourceType) {
+		if (Appointment.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Appointment.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Appointment.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Appointment.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Appointment.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
+++ b/src/server/profiles/appointmentresponse/appointmentresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let AppointmentResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AppointmentResponse.__resourceType !== resource_body.resourceType) {
+		if (AppointmentResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AppointmentResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AppointmentResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, AppointmentResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, AppointmentResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let AppointmentResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AppointmentResponse.__resourceType !== resource_body.resourceType) {
+		if (AppointmentResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AppointmentResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AppointmentResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, AppointmentResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, AppointmentResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/auditevent/auditevent.controller.js
+++ b/src/server/profiles/auditevent/auditevent.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let AuditEvent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AuditEvent.__resourceType !== resource_body.resourceType) {
+		if (AuditEvent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AuditEvent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AuditEvent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, AuditEvent.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, AuditEvent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let AuditEvent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (AuditEvent.__resourceType !== resource_body.resourceType) {
+		if (AuditEvent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${AuditEvent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${AuditEvent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, AuditEvent.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, AuditEvent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/basic/basic.controller.js
+++ b/src/server/profiles/basic/basic.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Basic = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Basic.__resourceType !== resource_body.resourceType) {
+		if (Basic.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Basic.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Basic.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Basic.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Basic.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Basic = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Basic.__resourceType !== resource_body.resourceType) {
+		if (Basic.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Basic.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Basic.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Basic.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Basic.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/binary/binary.controller.js
+++ b/src/server/profiles/binary/binary.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Binary = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Binary.__resourceType !== resource_body.resourceType) {
+		if (Binary.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Binary.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Binary.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Binary.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Binary.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Binary = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Binary.__resourceType !== resource_body.resourceType) {
+		if (Binary.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Binary.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Binary.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Binary.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Binary.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/bodysite/bodysite.controller.js
+++ b/src/server/profiles/bodysite/bodysite.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let BodySite = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (BodySite.__resourceType !== resource_body.resourceType) {
+		if (BodySite.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${BodySite.__resourceType}', received '${
+					`'resourceType' expected to have value of '${BodySite.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, BodySite.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, BodySite.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let BodySite = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (BodySite.__resourceType !== resource_body.resourceType) {
+		if (BodySite.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${BodySite.__resourceType}', received '${
+					`'resourceType' expected to have value of '${BodySite.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, BodySite.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, BodySite.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/bundle/bundle.controller.js
+++ b/src/server/profiles/bundle/bundle.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Bundle = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Bundle.__resourceType !== resource_body.resourceType) {
+		if (Bundle.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Bundle.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Bundle.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Bundle.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Bundle.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Bundle = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Bundle.__resourceType !== resource_body.resourceType) {
+		if (Bundle.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Bundle.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Bundle.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Bundle.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Bundle.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
+++ b/src/server/profiles/capabilitystatement/capabilitystatement.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CapabilityStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CapabilityStatement.__resourceType !== resource_body.resourceType) {
+		if (CapabilityStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CapabilityStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CapabilityStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CapabilityStatement.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CapabilityStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CapabilityStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CapabilityStatement.__resourceType !== resource_body.resourceType) {
+		if (CapabilityStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CapabilityStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CapabilityStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CapabilityStatement.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CapabilityStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/careplan/careplan.controller.js
+++ b/src/server/profiles/careplan/careplan.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CarePlan = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CarePlan.__resourceType !== resource_body.resourceType) {
+		if (CarePlan.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CarePlan.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CarePlan.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CarePlan.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CarePlan.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CarePlan = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CarePlan.__resourceType !== resource_body.resourceType) {
+		if (CarePlan.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CarePlan.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CarePlan.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CarePlan.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CarePlan.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/careteam/careteam.controller.js
+++ b/src/server/profiles/careteam/careteam.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CareTeam = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CareTeam.__resourceType !== resource_body.resourceType) {
+		if (CareTeam.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CareTeam.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CareTeam.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CareTeam.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CareTeam.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CareTeam = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CareTeam.__resourceType !== resource_body.resourceType) {
+		if (CareTeam.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CareTeam.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CareTeam.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CareTeam.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CareTeam.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/chargeitem/chargeitem.controller.js
+++ b/src/server/profiles/chargeitem/chargeitem.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ChargeItem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ChargeItem.__resourceType !== resource_body.resourceType) {
+		if (ChargeItem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ChargeItem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ChargeItem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ChargeItem.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ChargeItem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ChargeItem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ChargeItem.__resourceType !== resource_body.resourceType) {
+		if (ChargeItem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ChargeItem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ChargeItem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ChargeItem.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ChargeItem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/claim/claim.controller.js
+++ b/src/server/profiles/claim/claim.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Claim = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Claim.__resourceType !== resource_body.resourceType) {
+		if (Claim.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Claim.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Claim.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Claim.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Claim.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Claim = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Claim.__resourceType !== resource_body.resourceType) {
+		if (Claim.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Claim.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Claim.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Claim.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Claim.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/claimresponse/claimresponse.controller.js
+++ b/src/server/profiles/claimresponse/claimresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ClaimResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ClaimResponse.__resourceType !== resource_body.resourceType) {
+		if (ClaimResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ClaimResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ClaimResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ClaimResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ClaimResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ClaimResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ClaimResponse.__resourceType !== resource_body.resourceType) {
+		if (ClaimResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ClaimResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ClaimResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ClaimResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ClaimResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
+++ b/src/server/profiles/clinicalimpression/clinicalimpression.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ClinicalImpression = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ClinicalImpression.__resourceType !== resource_body.resourceType) {
+		if (ClinicalImpression.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ClinicalImpression.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ClinicalImpression.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ClinicalImpression.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ClinicalImpression.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ClinicalImpression = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ClinicalImpression.__resourceType !== resource_body.resourceType) {
+		if (ClinicalImpression.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ClinicalImpression.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ClinicalImpression.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ClinicalImpression.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ClinicalImpression.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/codesystem/codesystem.controller.js
+++ b/src/server/profiles/codesystem/codesystem.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CodeSystem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CodeSystem.__resourceType !== resource_body.resourceType) {
+		if (CodeSystem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CodeSystem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CodeSystem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CodeSystem.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CodeSystem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CodeSystem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CodeSystem.__resourceType !== resource_body.resourceType) {
+		if (CodeSystem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CodeSystem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CodeSystem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CodeSystem.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CodeSystem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/communication/communication.controller.js
+++ b/src/server/profiles/communication/communication.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Communication = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Communication.__resourceType !== resource_body.resourceType) {
+		if (Communication.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Communication.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Communication.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Communication.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Communication.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Communication = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Communication.__resourceType !== resource_body.resourceType) {
+		if (Communication.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Communication.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Communication.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Communication.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Communication.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/communicationrequest/communicationrequest.controller.js
+++ b/src/server/profiles/communicationrequest/communicationrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CommunicationRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CommunicationRequest.__resourceType !== resource_body.resourceType) {
+		if (CommunicationRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CommunicationRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CommunicationRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CommunicationRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CommunicationRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CommunicationRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CommunicationRequest.__resourceType !== resource_body.resourceType) {
+		if (CommunicationRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CommunicationRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CommunicationRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CommunicationRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CommunicationRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
+++ b/src/server/profiles/compartmentdefinition/compartmentdefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let CompartmentDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CompartmentDefinition.__resourceType !== resource_body.resourceType) {
+		if (CompartmentDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CompartmentDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CompartmentDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, CompartmentDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, CompartmentDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let CompartmentDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (CompartmentDefinition.__resourceType !== resource_body.resourceType) {
+		if (CompartmentDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${CompartmentDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${CompartmentDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, CompartmentDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, CompartmentDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/composition/composition.controller.js
+++ b/src/server/profiles/composition/composition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Composition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Composition.__resourceType !== resource_body.resourceType) {
+		if (Composition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Composition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Composition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Composition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Composition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Composition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Composition.__resourceType !== resource_body.resourceType) {
+		if (Composition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Composition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Composition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Composition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Composition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/conceptmap/conceptmap.controller.js
+++ b/src/server/profiles/conceptmap/conceptmap.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ConceptMap = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ConceptMap.__resourceType !== resource_body.resourceType) {
+		if (ConceptMap.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ConceptMap.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ConceptMap.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ConceptMap.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ConceptMap.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ConceptMap = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ConceptMap.__resourceType !== resource_body.resourceType) {
+		if (ConceptMap.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ConceptMap.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ConceptMap.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ConceptMap.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ConceptMap.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/condition/condition.controller.js
+++ b/src/server/profiles/condition/condition.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Condition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Condition.__resourceType !== resource_body.resourceType) {
+		if (Condition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Condition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Condition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Condition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Condition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Condition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Condition.__resourceType !== resource_body.resourceType) {
+		if (Condition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Condition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Condition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Condition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Condition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/consent/consent.controller.js
+++ b/src/server/profiles/consent/consent.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Consent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Consent.__resourceType !== resource_body.resourceType) {
+		if (Consent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Consent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Consent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Consent.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Consent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Consent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Consent.__resourceType !== resource_body.resourceType) {
+		if (Consent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Consent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Consent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Consent.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Consent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/contract/contract.controller.js
+++ b/src/server/profiles/contract/contract.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Contract = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Contract.__resourceType !== resource_body.resourceType) {
+		if (Contract.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Contract.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Contract.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Contract.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Contract.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Contract = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Contract.__resourceType !== resource_body.resourceType) {
+		if (Contract.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Contract.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Contract.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Contract.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Contract.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/coverage/coverage.controller.js
+++ b/src/server/profiles/coverage/coverage.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Coverage = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Coverage.__resourceType !== resource_body.resourceType) {
+		if (Coverage.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Coverage.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Coverage.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Coverage.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Coverage.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Coverage = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Coverage.__resourceType !== resource_body.resourceType) {
+		if (Coverage.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Coverage.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Coverage.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Coverage.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Coverage.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/dataelement/dataelement.controller.js
+++ b/src/server/profiles/dataelement/dataelement.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DataElement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DataElement.__resourceType !== resource_body.resourceType) {
+		if (DataElement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DataElement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DataElement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DataElement.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DataElement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DataElement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DataElement.__resourceType !== resource_body.resourceType) {
+		if (DataElement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DataElement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DataElement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DataElement.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DataElement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/detectedissue/detectedissue.controller.js
+++ b/src/server/profiles/detectedissue/detectedissue.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DetectedIssue = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DetectedIssue.__resourceType !== resource_body.resourceType) {
+		if (DetectedIssue.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DetectedIssue.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DetectedIssue.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DetectedIssue.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DetectedIssue.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DetectedIssue = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DetectedIssue.__resourceType !== resource_body.resourceType) {
+		if (DetectedIssue.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DetectedIssue.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DetectedIssue.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DetectedIssue.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DetectedIssue.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/device/device.controller.js
+++ b/src/server/profiles/device/device.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Device = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Device.__resourceType !== resource_body.resourceType) {
+		if (Device.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Device.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Device.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Device.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Device.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Device = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Device.__resourceType !== resource_body.resourceType) {
+		if (Device.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Device.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Device.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Device.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Device.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/devicecomponent/devicecomponent.controller.js
+++ b/src/server/profiles/devicecomponent/devicecomponent.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DeviceComponent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceComponent.__resourceType !== resource_body.resourceType) {
+		if (DeviceComponent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceComponent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceComponent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DeviceComponent.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DeviceComponent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DeviceComponent = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceComponent.__resourceType !== resource_body.resourceType) {
+		if (DeviceComponent.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceComponent.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceComponent.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DeviceComponent.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DeviceComponent.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/devicemetric/devicemetric.controller.js
+++ b/src/server/profiles/devicemetric/devicemetric.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DeviceMetric = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceMetric.__resourceType !== resource_body.resourceType) {
+		if (DeviceMetric.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceMetric.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceMetric.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DeviceMetric.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DeviceMetric.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DeviceMetric = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceMetric.__resourceType !== resource_body.resourceType) {
+		if (DeviceMetric.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceMetric.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceMetric.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DeviceMetric.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DeviceMetric.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/devicerequest/devicerequest.controller.js
+++ b/src/server/profiles/devicerequest/devicerequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DeviceRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceRequest.__resourceType !== resource_body.resourceType) {
+		if (DeviceRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DeviceRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DeviceRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DeviceRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceRequest.__resourceType !== resource_body.resourceType) {
+		if (DeviceRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DeviceRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DeviceRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
+++ b/src/server/profiles/deviceusestatement/deviceusestatement.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DeviceUseStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceUseStatement.__resourceType !== resource_body.resourceType) {
+		if (DeviceUseStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceUseStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceUseStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DeviceUseStatement.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DeviceUseStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DeviceUseStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DeviceUseStatement.__resourceType !== resource_body.resourceType) {
+		if (DeviceUseStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DeviceUseStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DeviceUseStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DeviceUseStatement.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DeviceUseStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
+++ b/src/server/profiles/diagnosticreport/diagnosticreport.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DiagnosticReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DiagnosticReport.__resourceType !== resource_body.resourceType) {
+		if (DiagnosticReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DiagnosticReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DiagnosticReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DiagnosticReport.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DiagnosticReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DiagnosticReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DiagnosticReport.__resourceType !== resource_body.resourceType) {
+		if (DiagnosticReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DiagnosticReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DiagnosticReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DiagnosticReport.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DiagnosticReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/documentmanifest/documentmanifest.controller.js
+++ b/src/server/profiles/documentmanifest/documentmanifest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DocumentManifest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DocumentManifest.__resourceType !== resource_body.resourceType) {
+		if (DocumentManifest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DocumentManifest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DocumentManifest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DocumentManifest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DocumentManifest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DocumentManifest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DocumentManifest.__resourceType !== resource_body.resourceType) {
+		if (DocumentManifest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DocumentManifest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DocumentManifest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DocumentManifest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DocumentManifest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/documentreference/documentreference.controller.js
+++ b/src/server/profiles/documentreference/documentreference.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let DocumentReference = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DocumentReference.__resourceType !== resource_body.resourceType) {
+		if (DocumentReference.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DocumentReference.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DocumentReference.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, DocumentReference.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, DocumentReference.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let DocumentReference = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (DocumentReference.__resourceType !== resource_body.resourceType) {
+		if (DocumentReference.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${DocumentReference.__resourceType}', received '${
+					`'resourceType' expected to have value of '${DocumentReference.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, DocumentReference.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, DocumentReference.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
+++ b/src/server/profiles/eligibilityrequest/eligibilityrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let EligibilityRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EligibilityRequest.__resourceType !== resource_body.resourceType) {
+		if (EligibilityRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EligibilityRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EligibilityRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, EligibilityRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, EligibilityRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let EligibilityRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EligibilityRequest.__resourceType !== resource_body.resourceType) {
+		if (EligibilityRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EligibilityRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EligibilityRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, EligibilityRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, EligibilityRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
+++ b/src/server/profiles/eligibilityresponse/eligibilityresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let EligibilityResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EligibilityResponse.__resourceType !== resource_body.resourceType) {
+		if (EligibilityResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EligibilityResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EligibilityResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, EligibilityResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, EligibilityResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let EligibilityResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EligibilityResponse.__resourceType !== resource_body.resourceType) {
+		if (EligibilityResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EligibilityResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EligibilityResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, EligibilityResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, EligibilityResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/encounter/encounter.controller.js
+++ b/src/server/profiles/encounter/encounter.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Encounter = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Encounter.__resourceType !== resource_body.resourceType) {
+		if (Encounter.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Encounter.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Encounter.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Encounter.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Encounter.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Encounter = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Encounter.__resourceType !== resource_body.resourceType) {
+		if (Encounter.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Encounter.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Encounter.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Encounter.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Encounter.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/endpoint/endpoint.controller.js
+++ b/src/server/profiles/endpoint/endpoint.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Endpoint = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Endpoint.__resourceType !== resource_body.resourceType) {
+		if (Endpoint.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Endpoint.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Endpoint.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Endpoint.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Endpoint.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Endpoint = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Endpoint.__resourceType !== resource_body.resourceType) {
+		if (Endpoint.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Endpoint.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Endpoint.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Endpoint.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Endpoint.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
+++ b/src/server/profiles/enrollmentrequest/enrollmentrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let EnrollmentRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EnrollmentRequest.__resourceType !== resource_body.resourceType) {
+		if (EnrollmentRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EnrollmentRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EnrollmentRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, EnrollmentRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, EnrollmentRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let EnrollmentRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EnrollmentRequest.__resourceType !== resource_body.resourceType) {
+		if (EnrollmentRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EnrollmentRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EnrollmentRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, EnrollmentRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, EnrollmentRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
+++ b/src/server/profiles/enrollmentresponse/enrollmentresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let EnrollmentResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EnrollmentResponse.__resourceType !== resource_body.resourceType) {
+		if (EnrollmentResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EnrollmentResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EnrollmentResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, EnrollmentResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, EnrollmentResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let EnrollmentResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EnrollmentResponse.__resourceType !== resource_body.resourceType) {
+		if (EnrollmentResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EnrollmentResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EnrollmentResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, EnrollmentResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, EnrollmentResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/episodeofcare/episodeofcare.controller.js
+++ b/src/server/profiles/episodeofcare/episodeofcare.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let EpisodeOfCare = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EpisodeOfCare.__resourceType !== resource_body.resourceType) {
+		if (EpisodeOfCare.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EpisodeOfCare.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EpisodeOfCare.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, EpisodeOfCare.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, EpisodeOfCare.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let EpisodeOfCare = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (EpisodeOfCare.__resourceType !== resource_body.resourceType) {
+		if (EpisodeOfCare.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${EpisodeOfCare.__resourceType}', received '${
+					`'resourceType' expected to have value of '${EpisodeOfCare.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, EpisodeOfCare.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, EpisodeOfCare.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/expansionprofile/expansionprofile.controller.js
+++ b/src/server/profiles/expansionprofile/expansionprofile.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ExpansionProfile = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ExpansionProfile.__resourceType !== resource_body.resourceType) {
+		if (ExpansionProfile.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ExpansionProfile.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ExpansionProfile.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ExpansionProfile.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ExpansionProfile.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ExpansionProfile = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ExpansionProfile.__resourceType !== resource_body.resourceType) {
+		if (ExpansionProfile.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ExpansionProfile.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ExpansionProfile.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ExpansionProfile.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ExpansionProfile.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
+++ b/src/server/profiles/explanationofbenefit/explanationofbenefit.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ExplanationOfBenefit = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ExplanationOfBenefit.__resourceType !== resource_body.resourceType) {
+		if (ExplanationOfBenefit.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ExplanationOfBenefit.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ExplanationOfBenefit.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ExplanationOfBenefit.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ExplanationOfBenefit.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ExplanationOfBenefit = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ExplanationOfBenefit.__resourceType !== resource_body.resourceType) {
+		if (ExplanationOfBenefit.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ExplanationOfBenefit.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ExplanationOfBenefit.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ExplanationOfBenefit.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ExplanationOfBenefit.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
+++ b/src/server/profiles/familymemberhistory/familymemberhistory.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let FamilyMemberHistory = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (FamilyMemberHistory.__resourceType !== resource_body.resourceType) {
+		if (FamilyMemberHistory.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${FamilyMemberHistory.__resourceType}', received '${
+					`'resourceType' expected to have value of '${FamilyMemberHistory.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, FamilyMemberHistory.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, FamilyMemberHistory.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let FamilyMemberHistory = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (FamilyMemberHistory.__resourceType !== resource_body.resourceType) {
+		if (FamilyMemberHistory.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${FamilyMemberHistory.__resourceType}', received '${
+					`'resourceType' expected to have value of '${FamilyMemberHistory.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, FamilyMemberHistory.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, FamilyMemberHistory.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/flag/flag.controller.js
+++ b/src/server/profiles/flag/flag.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Flag = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Flag.__resourceType !== resource_body.resourceType) {
+		if (Flag.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Flag.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Flag.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Flag.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Flag.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Flag = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Flag.__resourceType !== resource_body.resourceType) {
+		if (Flag.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Flag.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Flag.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -135,7 +135,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Flag.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Flag.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/goal/goal.controller.js
+++ b/src/server/profiles/goal/goal.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Goal = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Goal.__resourceType !== resource_body.resourceType) {
+		if (Goal.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Goal.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Goal.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Goal.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Goal.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Goal = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Goal.__resourceType !== resource_body.resourceType) {
+		if (Goal.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Goal.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Goal.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -135,7 +135,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Goal.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Goal.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/graphdefinition/graphdefinition.controller.js
+++ b/src/server/profiles/graphdefinition/graphdefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let GraphDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (GraphDefinition.__resourceType !== resource_body.resourceType) {
+		if (GraphDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${GraphDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${GraphDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, GraphDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, GraphDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let GraphDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (GraphDefinition.__resourceType !== resource_body.resourceType) {
+		if (GraphDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${GraphDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${GraphDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, GraphDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, GraphDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/group/group.controller.js
+++ b/src/server/profiles/group/group.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Group = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Group.__resourceType !== resource_body.resourceType) {
+		if (Group.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Group.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Group.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Group.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Group.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Group = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Group.__resourceType !== resource_body.resourceType) {
+		if (Group.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Group.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Group.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Group.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Group.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
+++ b/src/server/profiles/guidanceresponse/guidanceresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let GuidanceResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (GuidanceResponse.__resourceType !== resource_body.resourceType) {
+		if (GuidanceResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${GuidanceResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${GuidanceResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, GuidanceResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, GuidanceResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let GuidanceResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (GuidanceResponse.__resourceType !== resource_body.resourceType) {
+		if (GuidanceResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${GuidanceResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${GuidanceResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, GuidanceResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, GuidanceResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/healthcareservice/healthcareservice.controller.js
+++ b/src/server/profiles/healthcareservice/healthcareservice.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let HealthcareService = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (HealthcareService.__resourceType !== resource_body.resourceType) {
+		if (HealthcareService.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${HealthcareService.__resourceType}', received '${
+					`'resourceType' expected to have value of '${HealthcareService.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, HealthcareService.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, HealthcareService.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let HealthcareService = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (HealthcareService.__resourceType !== resource_body.resourceType) {
+		if (HealthcareService.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${HealthcareService.__resourceType}', received '${
+					`'resourceType' expected to have value of '${HealthcareService.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, HealthcareService.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, HealthcareService.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
+++ b/src/server/profiles/imagingmanifest/imagingmanifest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ImagingManifest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImagingManifest.__resourceType !== resource_body.resourceType) {
+		if (ImagingManifest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImagingManifest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImagingManifest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ImagingManifest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ImagingManifest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ImagingManifest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImagingManifest.__resourceType !== resource_body.resourceType) {
+		if (ImagingManifest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImagingManifest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImagingManifest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ImagingManifest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ImagingManifest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/imagingstudy/imagingstudy.controller.js
+++ b/src/server/profiles/imagingstudy/imagingstudy.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ImagingStudy = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImagingStudy.__resourceType !== resource_body.resourceType) {
+		if (ImagingStudy.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImagingStudy.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImagingStudy.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ImagingStudy.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ImagingStudy.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ImagingStudy = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImagingStudy.__resourceType !== resource_body.resourceType) {
+		if (ImagingStudy.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImagingStudy.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImagingStudy.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ImagingStudy.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ImagingStudy.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/immunization/immunization.controller.js
+++ b/src/server/profiles/immunization/immunization.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Immunization = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Immunization.__resourceType !== resource_body.resourceType) {
+		if (Immunization.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Immunization.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Immunization.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Immunization.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Immunization.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Immunization = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Immunization.__resourceType !== resource_body.resourceType) {
+		if (Immunization.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Immunization.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Immunization.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Immunization.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Immunization.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
+++ b/src/server/profiles/immunizationrecommendation/immunizationrecommendation.controller.js
@@ -93,10 +93,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ImmunizationRecommendation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImmunizationRecommendation.__resourceType !== resource_body.resourceType) {
+		if (ImmunizationRecommendation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImmunizationRecommendation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImmunizationRecommendation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -110,7 +110,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ImmunizationRecommendation.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ImmunizationRecommendation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -131,10 +131,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ImmunizationRecommendation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImmunizationRecommendation.__resourceType !== resource_body.resourceType) {
+		if (ImmunizationRecommendation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImmunizationRecommendation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImmunizationRecommendation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -148,7 +148,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ImmunizationRecommendation.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ImmunizationRecommendation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/implementationguide/implementationguide.controller.js
+++ b/src/server/profiles/implementationguide/implementationguide.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ImplementationGuide = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImplementationGuide.__resourceType !== resource_body.resourceType) {
+		if (ImplementationGuide.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImplementationGuide.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImplementationGuide.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ImplementationGuide.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ImplementationGuide.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ImplementationGuide = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ImplementationGuide.__resourceType !== resource_body.resourceType) {
+		if (ImplementationGuide.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ImplementationGuide.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ImplementationGuide.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ImplementationGuide.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ImplementationGuide.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/library/library.controller.js
+++ b/src/server/profiles/library/library.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Library = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Library.__resourceType !== resource_body.resourceType) {
+		if (Library.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Library.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Library.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Library.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Library.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Library = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Library.__resourceType !== resource_body.resourceType) {
+		if (Library.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Library.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Library.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Library.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Library.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/linkage/linkage.controller.js
+++ b/src/server/profiles/linkage/linkage.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Linkage = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Linkage.__resourceType !== resource_body.resourceType) {
+		if (Linkage.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Linkage.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Linkage.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Linkage.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Linkage.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Linkage = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Linkage.__resourceType !== resource_body.resourceType) {
+		if (Linkage.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Linkage.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Linkage.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Linkage.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Linkage.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/list/list.controller.js
+++ b/src/server/profiles/list/list.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let List = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (List.__resourceType !== resource_body.resourceType) {
+		if (List.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${List.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${List.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, List.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, List.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let List = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (List.__resourceType !== resource_body.resourceType) {
+		if (List.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${List.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${List.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -135,7 +135,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, List.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, List.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/location/location.controller.js
+++ b/src/server/profiles/location/location.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Location = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Location.__resourceType !== resource_body.resourceType) {
+		if (Location.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Location.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Location.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Location.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Location.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Location = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Location.__resourceType !== resource_body.resourceType) {
+		if (Location.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Location.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Location.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Location.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Location.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/measure/measure.controller.js
+++ b/src/server/profiles/measure/measure.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Measure = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Measure.__resourceType !== resource_body.resourceType) {
+		if (Measure.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Measure.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Measure.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Measure.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Measure.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Measure = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Measure.__resourceType !== resource_body.resourceType) {
+		if (Measure.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Measure.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Measure.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Measure.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Measure.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/measurereport/measurereport.controller.js
+++ b/src/server/profiles/measurereport/measurereport.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MeasureReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MeasureReport.__resourceType !== resource_body.resourceType) {
+		if (MeasureReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MeasureReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MeasureReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MeasureReport.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MeasureReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MeasureReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MeasureReport.__resourceType !== resource_body.resourceType) {
+		if (MeasureReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MeasureReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MeasureReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MeasureReport.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MeasureReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/media/media.controller.js
+++ b/src/server/profiles/media/media.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Media = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Media.__resourceType !== resource_body.resourceType) {
+		if (Media.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Media.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Media.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Media.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Media.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Media = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Media.__resourceType !== resource_body.resourceType) {
+		if (Media.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Media.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Media.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Media.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Media.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/medication/medication.controller.js
+++ b/src/server/profiles/medication/medication.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Medication = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Medication.__resourceType !== resource_body.resourceType) {
+		if (Medication.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Medication.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Medication.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Medication.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Medication.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Medication = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Medication.__resourceType !== resource_body.resourceType) {
+		if (Medication.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Medication.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Medication.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Medication.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Medication.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/medicationadministration/medicationadministration.controller.js
+++ b/src/server/profiles/medicationadministration/medicationadministration.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MedicationAdministration = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationAdministration.__resourceType !== resource_body.resourceType) {
+		if (MedicationAdministration.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationAdministration.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationAdministration.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MedicationAdministration.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MedicationAdministration.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MedicationAdministration = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationAdministration.__resourceType !== resource_body.resourceType) {
+		if (MedicationAdministration.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationAdministration.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationAdministration.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MedicationAdministration.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MedicationAdministration.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/medicationdispense/medicationdispense.controller.js
+++ b/src/server/profiles/medicationdispense/medicationdispense.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MedicationDispense = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationDispense.__resourceType !== resource_body.resourceType) {
+		if (MedicationDispense.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationDispense.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationDispense.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MedicationDispense.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MedicationDispense.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MedicationDispense = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationDispense.__resourceType !== resource_body.resourceType) {
+		if (MedicationDispense.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationDispense.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationDispense.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MedicationDispense.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MedicationDispense.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/medicationrequest/medicationrequest.controller.js
+++ b/src/server/profiles/medicationrequest/medicationrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MedicationRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationRequest.__resourceType !== resource_body.resourceType) {
+		if (MedicationRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MedicationRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MedicationRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MedicationRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationRequest.__resourceType !== resource_body.resourceType) {
+		if (MedicationRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MedicationRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MedicationRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/medicationstatement/medicationstatement.controller.js
+++ b/src/server/profiles/medicationstatement/medicationstatement.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MedicationStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationStatement.__resourceType !== resource_body.resourceType) {
+		if (MedicationStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MedicationStatement.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MedicationStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MedicationStatement = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MedicationStatement.__resourceType !== resource_body.resourceType) {
+		if (MedicationStatement.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MedicationStatement.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MedicationStatement.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MedicationStatement.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MedicationStatement.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/messagedefinition/messagedefinition.controller.js
+++ b/src/server/profiles/messagedefinition/messagedefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MessageDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MessageDefinition.__resourceType !== resource_body.resourceType) {
+		if (MessageDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MessageDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MessageDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MessageDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MessageDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MessageDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MessageDefinition.__resourceType !== resource_body.resourceType) {
+		if (MessageDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MessageDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MessageDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MessageDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MessageDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/messageheader/messageheader.controller.js
+++ b/src/server/profiles/messageheader/messageheader.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let MessageHeader = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MessageHeader.__resourceType !== resource_body.resourceType) {
+		if (MessageHeader.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MessageHeader.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MessageHeader.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, MessageHeader.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, MessageHeader.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let MessageHeader = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (MessageHeader.__resourceType !== resource_body.resourceType) {
+		if (MessageHeader.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${MessageHeader.__resourceType}', received '${
+					`'resourceType' expected to have value of '${MessageHeader.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, MessageHeader.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, MessageHeader.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/namingsystem/namingsystem.controller.js
+++ b/src/server/profiles/namingsystem/namingsystem.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let NamingSystem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (NamingSystem.__resourceType !== resource_body.resourceType) {
+		if (NamingSystem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${NamingSystem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${NamingSystem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, NamingSystem.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, NamingSystem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let NamingSystem = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (NamingSystem.__resourceType !== resource_body.resourceType) {
+		if (NamingSystem.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${NamingSystem.__resourceType}', received '${
+					`'resourceType' expected to have value of '${NamingSystem.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, NamingSystem.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, NamingSystem.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/nutritionorder/nutritionorder.controller.js
+++ b/src/server/profiles/nutritionorder/nutritionorder.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let NutritionOrder = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (NutritionOrder.__resourceType !== resource_body.resourceType) {
+		if (NutritionOrder.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${NutritionOrder.__resourceType}', received '${
+					`'resourceType' expected to have value of '${NutritionOrder.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, NutritionOrder.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, NutritionOrder.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let NutritionOrder = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (NutritionOrder.__resourceType !== resource_body.resourceType) {
+		if (NutritionOrder.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${NutritionOrder.__resourceType}', received '${
+					`'resourceType' expected to have value of '${NutritionOrder.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, NutritionOrder.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, NutritionOrder.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/observation/observation.controller.js
+++ b/src/server/profiles/observation/observation.controller.js
@@ -81,10 +81,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		// Get a version specific observation
 		let Observation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Observation.__resourceType !== resource_body.resourceType) {
+		if (Observation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Observation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Observation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -98,7 +98,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Observation.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Observation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -121,10 +121,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		// Get a version specific observation
 		let Observation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Observation.__resourceType !== resource_body.resourceType) {
+		if (Observation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Observation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Observation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -138,7 +138,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Observation.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Observation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/operationdefinition/operationdefinition.controller.js
+++ b/src/server/profiles/operationdefinition/operationdefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let OperationDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (OperationDefinition.__resourceType !== resource_body.resourceType) {
+		if (OperationDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${OperationDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${OperationDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, OperationDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, OperationDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let OperationDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (OperationDefinition.__resourceType !== resource_body.resourceType) {
+		if (OperationDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${OperationDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${OperationDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, OperationDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, OperationDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/organization/organization.controller.js
+++ b/src/server/profiles/organization/organization.controller.js
@@ -88,10 +88,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 
 		let Organization = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Organization.__resourceType !== resource_body.resourceType) {
+		if (Organization.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Organization.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Organization.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -105,7 +105,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Organization.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Organization.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -128,10 +128,10 @@ module.exports.update = function update({ profile, logger, config }) {
 
 		let Organization = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Organization.__resourceType !== resource_body.resourceType) {
+		if (Organization.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Organization.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Organization.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -145,7 +145,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Organization.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Organization.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/patient/patient.controller.js
+++ b/src/server/profiles/patient/patient.controller.js
@@ -94,10 +94,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		// Get a version specific patient
 		let Patient = require(resolveFromVersion(base_version, 'Patient'));
 		// Validate the resource type before creating it
-		if (Patient.__resourceType !== resource_body.resourceType) {
+		if (Patient.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Patient.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Patient.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -111,7 +111,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Patient.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Patient.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -134,10 +134,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		// Get a version specific patient
 		let Patient = require(resolveFromVersion(base_version, 'Patient'));
 		// Validate the resource type before creating it
-		if (Patient.__resourceType !== resource_body.resourceType) {
+		if (Patient.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Patient.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Patient.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -151,7 +151,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Patient.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Patient.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -250,7 +250,7 @@ module.exports.patch = function patch({ profile, logger, config }) {
 		return service
 			.patch(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Patient.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Patient.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/paymentnotice/paymentnotice.controller.js
+++ b/src/server/profiles/paymentnotice/paymentnotice.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let PaymentNotice = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PaymentNotice.__resourceType !== resource_body.resourceType) {
+		if (PaymentNotice.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PaymentNotice.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PaymentNotice.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, PaymentNotice.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, PaymentNotice.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let PaymentNotice = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PaymentNotice.__resourceType !== resource_body.resourceType) {
+		if (PaymentNotice.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PaymentNotice.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PaymentNotice.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, PaymentNotice.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, PaymentNotice.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
+++ b/src/server/profiles/paymentreconciliation/paymentreconciliation.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let PaymentReconciliation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PaymentReconciliation.__resourceType !== resource_body.resourceType) {
+		if (PaymentReconciliation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PaymentReconciliation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PaymentReconciliation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, PaymentReconciliation.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, PaymentReconciliation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let PaymentReconciliation = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PaymentReconciliation.__resourceType !== resource_body.resourceType) {
+		if (PaymentReconciliation.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PaymentReconciliation.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PaymentReconciliation.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, PaymentReconciliation.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, PaymentReconciliation.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/person/person.controller.js
+++ b/src/server/profiles/person/person.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Person = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Person.__resourceType !== resource_body.resourceType) {
+		if (Person.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Person.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Person.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Person.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Person.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Person = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Person.__resourceType !== resource_body.resourceType) {
+		if (Person.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Person.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Person.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Person.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Person.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/plandefinition/plandefinition.controller.js
+++ b/src/server/profiles/plandefinition/plandefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let PlanDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PlanDefinition.__resourceType !== resource_body.resourceType) {
+		if (PlanDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PlanDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PlanDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, PlanDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, PlanDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let PlanDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PlanDefinition.__resourceType !== resource_body.resourceType) {
+		if (PlanDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PlanDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PlanDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, PlanDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, PlanDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/practitioner/practitioner.controller.js
+++ b/src/server/profiles/practitioner/practitioner.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Practitioner = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Practitioner.__resourceType !== resource_body.resourceType) {
+		if (Practitioner.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Practitioner.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Practitioner.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Practitioner.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Practitioner.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Practitioner = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Practitioner.__resourceType !== resource_body.resourceType) {
+		if (Practitioner.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Practitioner.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Practitioner.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Practitioner.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Practitioner.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/practitionerrole/practitionerrole.controller.js
+++ b/src/server/profiles/practitionerrole/practitionerrole.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let PractitionerRole = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PractitionerRole.__resourceType !== resource_body.resourceType) {
+		if (PractitionerRole.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PractitionerRole.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PractitionerRole.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, PractitionerRole.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, PractitionerRole.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let PractitionerRole = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (PractitionerRole.__resourceType !== resource_body.resourceType) {
+		if (PractitionerRole.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${PractitionerRole.__resourceType}', received '${
+					`'resourceType' expected to have value of '${PractitionerRole.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, PractitionerRole.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, PractitionerRole.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/procedure/procedure.controller.js
+++ b/src/server/profiles/procedure/procedure.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Procedure = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Procedure.__resourceType !== resource_body.resourceType) {
+		if (Procedure.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Procedure.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Procedure.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Procedure.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Procedure.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Procedure = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Procedure.__resourceType !== resource_body.resourceType) {
+		if (Procedure.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Procedure.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Procedure.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Procedure.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Procedure.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/procedurerequest/procedurerequest.controller.js
+++ b/src/server/profiles/procedurerequest/procedurerequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ProcedureRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcedureRequest.__resourceType !== resource_body.resourceType) {
+		if (ProcedureRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcedureRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcedureRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ProcedureRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ProcedureRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ProcedureRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcedureRequest.__resourceType !== resource_body.resourceType) {
+		if (ProcedureRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcedureRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcedureRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ProcedureRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ProcedureRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/processrequest/processrequest.controller.js
+++ b/src/server/profiles/processrequest/processrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ProcessRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcessRequest.__resourceType !== resource_body.resourceType) {
+		if (ProcessRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcessRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcessRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ProcessRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ProcessRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ProcessRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcessRequest.__resourceType !== resource_body.resourceType) {
+		if (ProcessRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcessRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcessRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ProcessRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ProcessRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/processresponse/processresponse.controller.js
+++ b/src/server/profiles/processresponse/processresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ProcessResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcessResponse.__resourceType !== resource_body.resourceType) {
+		if (ProcessResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcessResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcessResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ProcessResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ProcessResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ProcessResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ProcessResponse.__resourceType !== resource_body.resourceType) {
+		if (ProcessResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ProcessResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ProcessResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ProcessResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ProcessResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/provenance/provenance.controller.js
+++ b/src/server/profiles/provenance/provenance.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Provenance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Provenance.__resourceType !== resource_body.resourceType) {
+		if (Provenance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Provenance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Provenance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Provenance.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Provenance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Provenance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Provenance.__resourceType !== resource_body.resourceType) {
+		if (Provenance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Provenance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Provenance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Provenance.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Provenance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/questionnaire/questionnaire.controller.js
+++ b/src/server/profiles/questionnaire/questionnaire.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Questionnaire = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Questionnaire.__resourceType !== resource_body.resourceType) {
+		if (Questionnaire.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Questionnaire.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Questionnaire.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Questionnaire.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Questionnaire.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Questionnaire = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Questionnaire.__resourceType !== resource_body.resourceType) {
+		if (Questionnaire.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Questionnaire.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Questionnaire.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Questionnaire.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Questionnaire.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
+++ b/src/server/profiles/questionnaireresponse/questionnaireresponse.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let QuestionnaireResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (QuestionnaireResponse.__resourceType !== resource_body.resourceType) {
+		if (QuestionnaireResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${QuestionnaireResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${QuestionnaireResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, QuestionnaireResponse.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, QuestionnaireResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let QuestionnaireResponse = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (QuestionnaireResponse.__resourceType !== resource_body.resourceType) {
+		if (QuestionnaireResponse.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${QuestionnaireResponse.__resourceType}', received '${
+					`'resourceType' expected to have value of '${QuestionnaireResponse.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, QuestionnaireResponse.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, QuestionnaireResponse.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/referralrequest/referralrequest.controller.js
+++ b/src/server/profiles/referralrequest/referralrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ReferralRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ReferralRequest.__resourceType !== resource_body.resourceType) {
+		if (ReferralRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ReferralRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ReferralRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ReferralRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ReferralRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ReferralRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ReferralRequest.__resourceType !== resource_body.resourceType) {
+		if (ReferralRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ReferralRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ReferralRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ReferralRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ReferralRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/relatedperson/relatedperson.controller.js
+++ b/src/server/profiles/relatedperson/relatedperson.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let RelatedPerson = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RelatedPerson.__resourceType !== resource_body.resourceType) {
+		if (RelatedPerson.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RelatedPerson.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RelatedPerson.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, RelatedPerson.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, RelatedPerson.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let RelatedPerson = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RelatedPerson.__resourceType !== resource_body.resourceType) {
+		if (RelatedPerson.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RelatedPerson.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RelatedPerson.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, RelatedPerson.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, RelatedPerson.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/requestgroup/requestgroup.controller.js
+++ b/src/server/profiles/requestgroup/requestgroup.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let RequestGroup = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RequestGroup.__resourceType !== resource_body.resourceType) {
+		if (RequestGroup.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RequestGroup.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RequestGroup.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, RequestGroup.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, RequestGroup.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let RequestGroup = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RequestGroup.__resourceType !== resource_body.resourceType) {
+		if (RequestGroup.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RequestGroup.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RequestGroup.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, RequestGroup.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, RequestGroup.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/researchstudy/researchstudy.controller.js
+++ b/src/server/profiles/researchstudy/researchstudy.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ResearchStudy = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ResearchStudy.__resourceType !== resource_body.resourceType) {
+		if (ResearchStudy.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ResearchStudy.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ResearchStudy.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ResearchStudy.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ResearchStudy.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ResearchStudy = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ResearchStudy.__resourceType !== resource_body.resourceType) {
+		if (ResearchStudy.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ResearchStudy.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ResearchStudy.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ResearchStudy.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ResearchStudy.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/researchsubject/researchsubject.controller.js
+++ b/src/server/profiles/researchsubject/researchsubject.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ResearchSubject = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ResearchSubject.__resourceType !== resource_body.resourceType) {
+		if (ResearchSubject.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ResearchSubject.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ResearchSubject.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ResearchSubject.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ResearchSubject.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ResearchSubject = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ResearchSubject.__resourceType !== resource_body.resourceType) {
+		if (ResearchSubject.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ResearchSubject.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ResearchSubject.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ResearchSubject.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ResearchSubject.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/riskassessment/riskassessment.controller.js
+++ b/src/server/profiles/riskassessment/riskassessment.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let RiskAssessment = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RiskAssessment.__resourceType !== resource_body.resourceType) {
+		if (RiskAssessment.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RiskAssessment.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RiskAssessment.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, RiskAssessment.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, RiskAssessment.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let RiskAssessment = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (RiskAssessment.__resourceType !== resource_body.resourceType) {
+		if (RiskAssessment.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${RiskAssessment.__resourceType}', received '${
+					`'resourceType' expected to have value of '${RiskAssessment.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, RiskAssessment.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, RiskAssessment.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/schedule/schedule.controller.js
+++ b/src/server/profiles/schedule/schedule.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Schedule = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Schedule.__resourceType !== resource_body.resourceType) {
+		if (Schedule.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Schedule.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Schedule.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Schedule.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Schedule.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Schedule = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Schedule.__resourceType !== resource_body.resourceType) {
+		if (Schedule.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Schedule.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Schedule.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Schedule.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Schedule.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/searchparameter/searchparameter.controller.js
+++ b/src/server/profiles/searchparameter/searchparameter.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let SearchParameter = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SearchParameter.__resourceType !== resource_body.resourceType) {
+		if (SearchParameter.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SearchParameter.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SearchParameter.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, SearchParameter.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, SearchParameter.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let SearchParameter = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SearchParameter.__resourceType !== resource_body.resourceType) {
+		if (SearchParameter.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SearchParameter.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SearchParameter.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, SearchParameter.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, SearchParameter.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/sequence/sequence.controller.js
+++ b/src/server/profiles/sequence/sequence.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Sequence = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Sequence.__resourceType !== resource_body.resourceType) {
+		if (Sequence.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Sequence.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Sequence.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Sequence.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Sequence.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Sequence = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Sequence.__resourceType !== resource_body.resourceType) {
+		if (Sequence.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Sequence.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Sequence.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Sequence.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Sequence.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/servicedefinition/servicedefinition.controller.js
+++ b/src/server/profiles/servicedefinition/servicedefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ServiceDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ServiceDefinition.__resourceType !== resource_body.resourceType) {
+		if (ServiceDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ServiceDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ServiceDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ServiceDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ServiceDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ServiceDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ServiceDefinition.__resourceType !== resource_body.resourceType) {
+		if (ServiceDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ServiceDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ServiceDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ServiceDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ServiceDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/slot/slot.controller.js
+++ b/src/server/profiles/slot/slot.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Slot = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Slot.__resourceType !== resource_body.resourceType) {
+		if (Slot.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Slot.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Slot.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Slot.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Slot.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Slot = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Slot.__resourceType !== resource_body.resourceType) {
+		if (Slot.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Slot.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Slot.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -135,7 +135,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Slot.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Slot.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/specimen/specimen.controller.js
+++ b/src/server/profiles/specimen/specimen.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Specimen = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Specimen.__resourceType !== resource_body.resourceType) {
+		if (Specimen.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Specimen.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Specimen.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Specimen.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Specimen.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Specimen = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Specimen.__resourceType !== resource_body.resourceType) {
+		if (Specimen.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Specimen.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Specimen.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Specimen.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Specimen.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/structuredefinition/structuredefinition.controller.js
+++ b/src/server/profiles/structuredefinition/structuredefinition.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let StructureDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (StructureDefinition.__resourceType !== resource_body.resourceType) {
+		if (StructureDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${StructureDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${StructureDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, StructureDefinition.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, StructureDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let StructureDefinition = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (StructureDefinition.__resourceType !== resource_body.resourceType) {
+		if (StructureDefinition.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${StructureDefinition.__resourceType}', received '${
+					`'resourceType' expected to have value of '${StructureDefinition.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, StructureDefinition.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, StructureDefinition.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/structuremap/structuremap.controller.js
+++ b/src/server/profiles/structuremap/structuremap.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let StructureMap = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (StructureMap.__resourceType !== resource_body.resourceType) {
+		if (StructureMap.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${StructureMap.__resourceType}', received '${
+					`'resourceType' expected to have value of '${StructureMap.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, StructureMap.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, StructureMap.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let StructureMap = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (StructureMap.__resourceType !== resource_body.resourceType) {
+		if (StructureMap.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${StructureMap.__resourceType}', received '${
+					`'resourceType' expected to have value of '${StructureMap.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, StructureMap.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, StructureMap.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/subscription/subscription.controller.js
+++ b/src/server/profiles/subscription/subscription.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Subscription = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Subscription.__resourceType !== resource_body.resourceType) {
+		if (Subscription.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Subscription.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Subscription.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Subscription.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Subscription.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Subscription = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Subscription.__resourceType !== resource_body.resourceType) {
+		if (Subscription.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Subscription.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Subscription.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Subscription.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Subscription.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/substance/substance.controller.js
+++ b/src/server/profiles/substance/substance.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Substance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Substance.__resourceType !== resource_body.resourceType) {
+		if (Substance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Substance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Substance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Substance.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Substance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Substance = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Substance.__resourceType !== resource_body.resourceType) {
+		if (Substance.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Substance.__resourceType}', received '${
+					`'resourceType' expected to have value of '${Substance.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Substance.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Substance.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/supplydelivery/supplydelivery.controller.js
+++ b/src/server/profiles/supplydelivery/supplydelivery.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let SupplyDelivery = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SupplyDelivery.__resourceType !== resource_body.resourceType) {
+		if (SupplyDelivery.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SupplyDelivery.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SupplyDelivery.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, SupplyDelivery.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, SupplyDelivery.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let SupplyDelivery = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SupplyDelivery.__resourceType !== resource_body.resourceType) {
+		if (SupplyDelivery.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SupplyDelivery.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SupplyDelivery.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, SupplyDelivery.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, SupplyDelivery.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/supplyrequest/supplyrequest.controller.js
+++ b/src/server/profiles/supplyrequest/supplyrequest.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let SupplyRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SupplyRequest.__resourceType !== resource_body.resourceType) {
+		if (SupplyRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SupplyRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SupplyRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, SupplyRequest.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, SupplyRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let SupplyRequest = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (SupplyRequest.__resourceType !== resource_body.resourceType) {
+		if (SupplyRequest.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${SupplyRequest.__resourceType}', received '${
+					`'resourceType' expected to have value of '${SupplyRequest.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, SupplyRequest.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, SupplyRequest.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/task/task.controller.js
+++ b/src/server/profiles/task/task.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let Task = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Task.__resourceType !== resource_body.resourceType) {
+		if (Task.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Task.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Task.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -99,7 +99,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, Task.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, Task.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -120,10 +120,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let Task = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (Task.__resourceType !== resource_body.resourceType) {
+		if (Task.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${Task.__resourceType}', received '${resource_body.resourceType}'`,
+					`'resourceType' expected to have value of '${Task.resourceType}', received '${resource_body.resourceType}'`,
 					base_version,
 				),
 			);
@@ -135,7 +135,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, Task.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, Task.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/testreport/testreport.controller.js
+++ b/src/server/profiles/testreport/testreport.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let TestReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (TestReport.__resourceType !== resource_body.resourceType) {
+		if (TestReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${TestReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${TestReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, TestReport.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, TestReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let TestReport = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (TestReport.__resourceType !== resource_body.resourceType) {
+		if (TestReport.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${TestReport.__resourceType}', received '${
+					`'resourceType' expected to have value of '${TestReport.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, TestReport.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, TestReport.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/testscript/testscript.controller.js
+++ b/src/server/profiles/testscript/testscript.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let TestScript = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (TestScript.__resourceType !== resource_body.resourceType) {
+		if (TestScript.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${TestScript.__resourceType}', received '${
+					`'resourceType' expected to have value of '${TestScript.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, TestScript.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, TestScript.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let TestScript = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (TestScript.__resourceType !== resource_body.resourceType) {
+		if (TestScript.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${TestScript.__resourceType}', received '${
+					`'resourceType' expected to have value of '${TestScript.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, TestScript.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, TestScript.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/valueset/valueset.controller.js
+++ b/src/server/profiles/valueset/valueset.controller.js
@@ -84,10 +84,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let ValueSet = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ValueSet.__resourceType !== resource_body.resourceType) {
+		if (ValueSet.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ValueSet.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ValueSet.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -101,7 +101,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, ValueSet.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, ValueSet.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -122,10 +122,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let ValueSet = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (ValueSet.__resourceType !== resource_body.resourceType) {
+		if (ValueSet.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${ValueSet.__resourceType}', received '${
+					`'resourceType' expected to have value of '${ValueSet.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -139,7 +139,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, ValueSet.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, ValueSet.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)

--- a/src/server/profiles/visionprescription/visionprescription.controller.js
+++ b/src/server/profiles/visionprescription/visionprescription.controller.js
@@ -86,10 +86,10 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		let resource_body = req.body;
 		let VisionPrescription = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (VisionPrescription.__resourceType !== resource_body.resourceType) {
+		if (VisionPrescription.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${VisionPrescription.__resourceType}', received '${
+					`'resourceType' expected to have value of '${VisionPrescription.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -103,7 +103,7 @@ module.exports.create = function create({ profile, logger, app, config }) {
 		return service
 			.create(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleCreateResponse(res, base_version, VisionPrescription.__resourceType, results, {
+				responseUtils.handleCreateResponse(res, base_version, VisionPrescription.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)
@@ -124,10 +124,10 @@ module.exports.update = function update({ profile, logger, config }) {
 		let resource_body = req.body;
 		let VisionPrescription = getResourceConstructor(base_version);
 		// Validate the resource type before creating it
-		if (VisionPrescription.__resourceType !== resource_body.resourceType) {
+		if (VisionPrescription.resourceType !== resource_body.resourceType) {
 			return next(
 				errors.invalidParameter(
-					`'resourceType' expected to have value of '${VisionPrescription.__resourceType}', received '${
+					`'resourceType' expected to have value of '${VisionPrescription.resourceType}', received '${
 						resource_body.resourceType
 					}'`,
 					base_version,
@@ -141,7 +141,7 @@ module.exports.update = function update({ profile, logger, config }) {
 		return service
 			.update(args, req.contexts, logger)
 			.then(results =>
-				responseUtils.handleUpdateResponse(res, base_version, VisionPrescription.__resourceType, results, {
+				responseUtils.handleUpdateResponse(res, base_version, VisionPrescription.resourceType, results, {
 					resourceUrl: config.auth.resourceServer,
 				}),
 			)


### PR DESCRIPTION
fix: rename __resourceType to resourceType in controllers

Tested creating and updating a patient resource in core.  It works as expected and when I intentionally introduce an error, I see the following `'resourceType' expected to have value of 'Patient', received 'Foobar'`. This fixes #161 