### PR TITLE
Started moving docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,76 +4,27 @@ Asymmetrik FHIR API Server
 
 [![Build Status](https://travis-ci.org/Asymmetrik/node-fhir-server-core.svg?branch=develop)](https://travis-ci.org/Asymmetrik/node-fhir-server-core) [![Known Vulnerabilities](https://snyk.io/test/github/asymmetrik/node-fhir-server-core/badge.svg?targetFile=package.json)](https://snyk.io/test/github/asymmetrik/node-fhir-server-core?targetFile=package.json)
 
-
 The Asymmetrik Extensible Server Framework for Healthcare allows organizations to build secure, interoperable solutions that can aggregate and expose healthcare resources via a common HL7® FHIR®-compatible REST API.  This server framework currently supports both DSTU2 (1.0.2) and STU3 (3.0.1) simultaneously.  You can decide to support both or just one by editing the configuration.
 
 The framework defines a core server, `node-fhir-server-core`, a simple, secure Node.js module built according to the FHIR specification and compliant with the [US Core](http://www.hl7.org/fhir/us/core/) implementation.
 
 For an example implementation using MongoDB, please refer to our Github repository that we used for the ONC FHIR Secure API Server Showdown Challenge, [https://github.com/Asymmetrik/node-fhir-server-mongo](https://github.com/Asymmetrik/node-fhir-server-mongo).
 
-
 <img src="https://www.asymmetrik.com/wp-content/uploads/2018/01/FHIR-Server-Architecture_Update.png" width="800">
 
-
 ## Prerequisites
-[Node.js](https://nodejs.org/en/) version later than 7.6, **but** not 8.5 (see [Attention](#attention)), and an understanding of [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) usage are required.
-
-Familiarity of the FHIR specification and whatever database containing the resources will assist in querying data and returning them in a format conforming to specification.
+[Node.js](https://nodejs.org/en/) version later than 7.6 is required, **but** you should not use 8.5 (see [Attention](#attention)).  A basic understanding of [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) and a familiarity of the FHIR specification is not required, but will be very helpful.
 
 ## Getting Started
-Install `node-fhir-server-core` as followed:
+Please see our [Getting Started](./docs/GettingStarted.md) guide for a walkthrough of how to set up our FHIR server.
 
-```shell
-# For yarn users
-yarn add @asymmetrik/node-fhir-server-core
-
-# For npm users
-npm install --save @asymmetrik/node-fhir-server-core
-```
-
-Once installed, the server can be required in the application.
-
-```javascript
-const FHIRServer = require('@asymmetrik/node-fhir-server-core');
-const { VERSIONS } = FHIRServer.constants;
-
-/**
-* The server will not run unless you have specified
-* at least one valid profile configuration
-*/
-const config = {
-	profiles: {
-		patient: {
-			service: path.resolve('./profiles/patient/patient.service'),
-			versions: [ VERSIONS['3_0_1'] ]
-		}
-	}
-};
-
-let main = function () {
-	let server = FHIRServer.initialize(config);
-	server.logger.info('FHIR Server successfully validated.');
-	// Start our server
-	server.listen(3000, () =>
-		server.logger.info('FHIR Server listening on localhost:' + 3000)
-	);
-};
-
-main();
-```
-
-## Usage
-For a complete list of all configuration options, supported profiles, their setups, best practices, authentication, etc. please consult our [Wiki](https://github.com/Asymmetrik/node-fhir-server-core/wiki). More documentation and examples will be added over time.
-
-## Roadmap
-- Support for more versions
-	- Multiple versions within DSTU2 and STU3
-	- R4
-- Remaining Endpoints (Terminology Operations)
-- Validation Service
-- Enhancing Authentication and adding additional scope checks
-- Better documentation on setup and configurations
-- Implementation guides and demos
+## Frequently Asked Questions
+- [What configurations does `FHIRServer.initialize()` accept?](./docs/ServerConfiguration.md)
+- [How do I configure a "profile"?](./docs/ConfiguringProfiles.md)
+- [Can I add more loggers or customize how the logger works?](./docs/CustomizeLogging.md)
+- [How do I customize the capability statement?](./docs/CustomCapability.md)
+- [How do I add custom operations?](./docs/CustomOperations.md)
+- [How do I enable/disable/customize access control (authentication)?](./docs/AccessControl.md)
 
 ## Philosophy
 Our project vision is to build an easy to use FHIR server that supports all resource profiles defined in the [US Core implementation guide](http://www.hl7.org/fhir/us/core/) and is built with security in mind from the ground up. We decided to use a plugin style architecture so implementors could focus on writing queries and not worry about all the other technical difficulties of securing the server.  As this project matures, we plan to support more resources, custom extensions, versions, write capabilities, etc.  

--- a/docs/AccessControl.md
+++ b/docs/AccessControl.md
@@ -1,0 +1,135 @@
+## Overview
+Access control is an important part to any application, especially one involving patient or medical information. In `node-fhir-server-core` we make it easier to implement by offering several solutions. We have some built in options that allow you to adopt Smart on FHIR with scope checking, but you can also just give us your own passport strategy. If none of these fit what your looking for, we export the server class that we use to build the app which exposes express and you can completely roll your own solution with your own middleware and strategies. For more information, please read through the examples below.
+
+## Available built-in options
+
+### Smart on FHIR
+We have built in support if you are using [Smart on FHIR](http://docs.smarthealthit.org/) however this requires you to have an operational OAuth2 server. While we try to make this as simple as possible, you will need a few things. You will need to enable it in the config and give it service that uses a Smart on FHIR strategy. Below is a walkthrough of how to set this up.
+
+#### Step One: Enable it in your config
+When setting up your FHIR server, add the following config entries to your current configuration:
+
+```javascript
+const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+
+let server = FHIRServer.initialize({
+	auth: {
+		// This is so we know you want scope validation, without this, we would only
+		// use the strategy
+		type: 'smart',
+		// Define our strategy here, for smart to work, we need the name to be bearer
+		// and to point to a service that exports a Smart on FHIR compatible strategy
+		strategy: {
+			name: 'bearer',
+			service: 'path/to/my/authentication.service.js'
+		}
+	}
+});
+```
+
+And that is all that is needed as far as config goes, but let's take a look at how to define this authentication service we just configured next.
+
+#### Step Two: Define a service
+If you are not familiar with writing passport strategies that is fine, you can use [`@asymmetrik/sof-strategy`](https://github.com/Asymmetrik/phx-tools/tree/master/packages/sof-strategy). To use this, create a file that looks like this:
+
+```javascript
+const smartBearerStrategy = require('@asymmetrik/sof-strategy');
+
+module.exports.strategy = smartBearerStrategy({
+	introspectionUrl: process.env.INTROSPECTION_URL,
+	clientSecret: process.env.CLIENT_SECRET,
+	clientId: process.env.CLIENT_ID
+});
+```
+
+You will also need to add `@asymmetrik/sof-strategy` as a dependency by running:
+
+```shell
+yarn add @asymmetrik/sof-strategy
+```
+
+And define some environment variables, `INTROSPECTION_URL`, `CLIENT_ID`, and `CLIENT_SECRET`. 
+
+That's it, this will enable Smart on FHIR authentication and scope validation. This strategy will make a request to the introspection url with a bearer token, CLIENT_ID and CLIENT_SECRET. This will attempt to authenticate the user and store the token on `req.user` so our scope middleware can validate the scopes for access to a requested resource.
+
+### PassportJS
+If you just need to provide your own passport strategy and don't want to use Smart on FHIR, you can do so very easily. In this example, we'll use a Basic Strategy, but the setup can be used for any strategy.
+
+In your config, add the following:
+
+```javascript
+let server = FHIRServer.initialize({
+	auth: {
+		strategy: {
+			name: 'basic',
+			service: 'path/to/my/basic.service.js'
+		}
+	}
+});
+```
+
+Then create the following `basic.service.js`:
+
+```javascript
+const { BasicStrategy } = require('passport-http');
+
+module.exports.strategy = new BasicStrategy((username, password, done) => {
+	if (username === 'user' && password === 'pass') {
+		return done(null, {});
+	} else {
+		return done(new Error('Invalid Username/Password'));
+	}
+});
+```
+
+And that's it, you now have basic auth setup. You would need to install `passport-http` via `yarn add passport-http` to make this work, but this is more of an example than something you should use in the real world. Please don't hardcode your username and password EVER.
+
+## How to customize
+There are some more advanced ways to setup the server. By default, if you do not provide any auth config, noop middleware will be used in it's place. So if you need to do more than what is provided through the config, you can.
+
+In our [Getting Started](https://github.com/Asymmetrik/node-fhir-server-core/wiki/Getting-Started) section, we showed you how to create a FHIR server by calling `initialize` and giving it some config, like so.
+
+```javascript
+const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+
+let server = FHIRServer.initialize({ ...someConfig });
+```
+
+What initialize is actually doing is just calling several internal methods. You can replicate the initialize method by doing the following:
+
+```javascript
+const { Server } = require('@asymmetrik/node-fhir-server-core');
+
+let server = new Server(config)
+	.configureMiddleware()
+	.configureSession()
+	.configureHelmet()
+	.configurePassport()
+	.setPublicDirectory()
+	.setProfileRoutes()
+	.setErrorRoutes();
+```
+
+This server instance exposes the express app instance via an `app` property. So you can do the following:
+
+```javascript
+const { Server } = require('@asymmetrik/node-fhir-server-core');
+
+let server = new Server(config);
+
+// Write your own custom middleware here for validating roles or using passport
+server.app.use(function (req, res, next) {
+	
+});
+
+// Call whichever of these functions you would like
+server.configureMiddleware()
+	.configureSession()
+	.configureHelmet()
+	.setPublicDirectory()
+	.setProfileRoutes()
+	.setErrorRoutes();
+
+// Finally start the server
+server.listen(3000);	
+```

--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -1,0 +1,177 @@
+## Overview
+
+We are currently focused on being fully compliant with the the latest major stable releases. In this section, we will discuss the options you have for enabling capabilities for each resource and version.
+
+## Profile Configuration
+
+### Supported Profiles
+
+Go to [src/constants.js](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/src/constants.js#L1) to find a list of all supported profiles with their associated keys.
+
+Profiles have the following configuration options:
+
+#### `service`
+
+- **Type:** `string|object`
+- **Description:** Path to a service module or the actual module itself (e.g. `require('path/to/service')`).
+- **Required:** `Yes`
+- **Default:** `none`
+
+#### `versions`
+
+- **Type:** `Array<string>`
+- **Description:** An array of strings containing the versions you intend to support. You cannot add anything you want here, only valid versions supported in core will be used. See [`exports.VERSIONS`](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/src/constants.js) in the constants file.
+- **Required:** `Yes`
+- **Default:** `none`
+
+#### `corsOptions`
+
+- **Type:** `object`
+- **Description:** Set profile specific cors options. These will override the default `corsOptions` set in the server config.  Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. This is controlled by `@asymmetrik/node-fhir-server-core` and cannot be overridden.
+- **Required:** `No`
+- **Default:** `none`
+
+## Profile(s) Interface
+
+Each profile has a predefined set of methods it can implement. If you do not want to support a particular interaction, for example, delete, then just don't implement the remove method. Each method you implement must return a promise and will receive the following three arguments (see sample code below):
+
+- `args` - An object containing all the sanitized arguments passed into the request. The arguments these contain will change based on the endpoint, e.g. create and delete have different args and search has different args between a patient and an observation. See below for more information.
+- `contexts` - Additional contextual information from the EHR or authentication system if available
+- `logger` - A Winston logger instance used by [`node-fhir-server-core`](https://github.com/Asymmetrik/node-fhir-server-core/). This is going to be marked as deprecated in future versions, we will expose the logger via a `require('@asymmetrik/node-fhir-server-core').logger` starting with 2.0.0. It will eventually be removed  completely.
+
+### Available Methods
+
+#### `search`
+
+- **Required:** No
+- **Description:** Get the resource given one of several valid argument(s) and/or  combination(s) of arguments in the req.query.
+- **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `/:base/[profile_name]` via GET and `/:base/[profile_name]/_search` via POST
+- **Example:**
+```javascript
+module.exports.search = (args, contexts, logger) => new Promise((resolve, reject) => {
+        // You will need to build your query based on the sanitized args
+	let query = myCustomQueryBuilder(args);
+	db.patients.find(query, (err, patients) => {
+		if (err) {
+			logger.error('Error with Patient.search');
+			return reject(err);
+		}
+		return resolve(patients);
+	});
+});
+```
+
+#### `searchById`
+
+- **Required:** No
+- **Description:** Get the patient given an id in the req.params.
+- **Return:** `Promise.<object, Error>`
+- **Routes:** Enables `:base/[profile_name]/:id` via GET
+- **Example:**
+```javascript
+// In patient service
+module.exports.searchById = (args, contexts, logger) => new Promise((resolve, reject) => {
+	db.patients.find({ _id: args.id }, (err, patient) => {
+		if (err) {
+			logger.error('Error with Patient.searchById');
+			return reject(err);
+		}
+		return resolve(patient);
+	});
+});
+```
+
+#### `create`
+
+- **Required:** No
+- **Description:** Create a FHIR resource.
+- **Return:** `Promise.<{ id: string, resource_version: string }, Error>`
+- **Routes:** Enables `/:base/[profile_name]` via POST 
+- **Example:**
+```javascript
+module.exports.create = (args, contexts, logger) => new Promise((resolve, reject) => {
+	let { id, resource } = args;
+	// This is a mongo specific thing
+	resource._id = id;
+	
+	db.patients.insert(resource, (err, response) => {
+		if (err) {
+			logger.error('Error with Patient.create');
+			return reject(err);
+		}
+		return resolve({
+			id: response._id,
+			// This is optional if you support versions
+			resource_version: 1
+		});
+	});
+});
+```
+
+#### `update`
+
+- **Required:** No
+- **Description:** Create or update a FHIR resource.
+- **Return:** `Promise.<{ id: string, resource_version: string }, Error>`
+- **Routes:** Enables `/:base/[profile_name]/:id` via PUT
+- **Example:**
+```javascript
+module.exports.update = (args, contexts, logger) => new Promise((resolve, reject) => {
+	let { id, resource } = args;
+	// This is a mongo specific thing
+	resource._id = id;
+	
+	db.patients.update(resource, (err, response) => {
+		if (err) {
+			logger.error('Error with Patient.update');
+			return reject(err);
+		}
+		return resolve({
+			id: response._id,
+			// This is optional if you support versions
+                        // The version is the version of the resource and not the FHIR version
+			resource_version: 1
+		});
+	});
+});
+```
+
+#### `remove`
+
+- **Required:** No
+- **Description:** Delete a FHIR resource.
+- **Return:** `Promise.<object, { code: string, message: string}>`
+- **Routes:** Enables `/:base/[profile_name]/:id` via DELETE
+- **Example:**
+```javascript
+module.exports.remove = (args, contexts, logger) => new Promise((resolve, reject) => {
+	let { id } = args;
+	
+	db.patients.remove({ _id: id }, (err, response) => {
+		if (err) {
+			logger.error('Error with Patient.delete');
+			return reject({
+				// Must be 405 (Method Not Allowed) or 409 (Conflict)
+				// 405 if you do not want to allow the delete
+				// 409 if you can't delete because of referential
+				// integrity or some other reason
+				code: 409,
+				message: 'Patient referenced in Observations and cannot be deleted. Please delete observations first.'
+			});
+		}
+		return resolve();
+	});
+});
+```
+
+## Profile(s) Arguments
+
+All profiles support this set of [common arguments](https://github.com/Asymmetrik/node-fhir-server-core/blob/master/src/server/profiles/common.arguments.js) as well as the arguments for each individual profile defined in the directories below. These come through to your service via the `args` argument.
+
+| Specification |  Directory |
+|---------------|------------|
+| [3.0.1](http://hl7.org/fhir/stu3/resourcelist.html)   | [src/server/standards/3_0_1/arguments](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/src/server/standards/3_0_1/arguments)  |
+| [1.0.2](http://hl7.org/fhir/dstu2/resourcelist.html) | [src/server/standards/1_0_2/arguments](https://github.com/Asymmetrik/node-fhir-server-core/tree/master/src/server/standards/1_0_2/arguments)  |
+
+You can download the structure definitions we are using for [STU3](https://www.hl7.org/fhir/stu3/downloads.html) and [DSTU2](https://www.hl7.org/fhir/dstu2/downloads.html) from the official FHIR website.

--- a/docs/CustomCapability.md
+++ b/docs/CustomCapability.md
@@ -1,0 +1,1 @@
+## Coming Soon

--- a/docs/CustomOperations.md
+++ b/docs/CustomOperations.md
@@ -1,0 +1,92 @@
+### Adding Custom Operations
+
+We now support custom $operations in node-fhir-server-core.  Let's walk through an example of adding `/$everything` operation to our Patient resource.  
+
+First, we will need to define an operation in our config.
+
+```js
+const config = {
+	profiles: {
+		patient: {
+			service: path.resolve('./src/patient.js'),
+			versions: [VERSIONS['3_0_1']],
+			operation: [{
+				name: 'everything',
+				route: '/$everything',
+				method: 'GET',
+				reference: 'https://www.hl7.org/fhir/patient-operation-everything.html'
+			}]
+		}
+	}
+}
+```
+
+If we FHIR up our server (GET IT? FHIR UP!?), we should get an error that tells us we have to make a function called everything in our `patient.js` file. Here is my error.
+
+`019-03-08T14:23:43.220Z - error:  message=Must include a function for patient with name everything that you specified in your configuration file.`
+
+In our patient.js file, just like our other routes, we will add a method for everything.
+
+```js
+module.exports.everything = (args, context, logger) => {
+  logger.info(`Running Patient $everything operation`)
+  return new Promise((resolve, reject) => {
+    try { 
+      // execute whatever custom operation you want.
+      resolve([])
+    } catch(err) {
+      reject(err)
+    }
+}
+```
+
+Restarting your server and navigating your browser to `/3_0_1/Patient/$everything`, your logger should generate the message above, and your should return an empty array.
+
+### Custom Operation by ID
+
+Now let's say you want to have a custom operation by Id.  Fear not, let's light a fhir under your keyboard and get to work.
+
+Let's add everything-by-id in patient. Go back to your config.
+
+```js
+const config = {
+	profiles: {
+		patient: {
+			service: path.resolve('./src/patient.js'),
+			versions: [VERSIONS['3_0_1']],
+			operation: [{
+				name: 'everything',
+				route: '/$everything',
+				method: 'GET',
+				reference: 'https://www.hl7.org/fhir/patient-operation-everything.html'
+			}, {
+				name: 'everything-by-id',
+				route: '/:id/$everything',
+				method: 'GET',
+        reference: 'https://www.hl7.org/fhir/patient-operation-everything.html'
+			}]
+		}
+	}
+}
+```
+
+If we restart the server we should see an error telling us to make a function called `everythingById` (notice the camelcase of the name property).
+
+Back in our `patient.js`
+
+```js
+module.exports.everythingById = (args, context, logger) => {
+  logger.info(`Running Patient /:id/$everything`)
+  return new Promise((resolve, reject) => {
+    try { 
+      // execute whatever custom operation you want to get patient by id.
+      resolve({resourceType: 'Patient', id: 1})
+    } catch(err) {
+      reject(err)
+    }
+}
+```
+
+Navigating in your browser to `/3_0_1/Patient/1/$everything` should trigger the logger info above and return your patient with ID of `1`.
+
+This should give you a start for making custom operations of any kind.  

--- a/docs/CustomizeLogging.md
+++ b/docs/CustomizeLogging.md
@@ -1,0 +1,1 @@
+## Coming Soon

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,0 +1,168 @@
+## Quick Overview
+
+This FHIR server library is intended to simplify the process of standing up your own FHIR server. We try to abstract a lot of the complicated pieces away so all you need to do is provide some configurations and write queries. In this getting started guide, we will walk you through using this library to get started building your own FHIR server. 
+
+**NOTE**: These instructions are for unix based systems. If you are using Windows, you may need to change some commands out for their Windows equivalent.
+
+## Creating a server
+
+Let's get started by installing some prerequisites.
+
+### Prerequisites
+
+1. Install the latest LTS for [Node.js](https://nodejs.org/en/). **You must have Node >= 7.7 installed**.
+2. Install [yarn](https://yarnpkg.com/en/docs/install).
+
+### Project setup
+
+In terminal, run the following:
+
+1. `mkdir fhir-server`
+2. `cd fhir-server`
+3. `yarn init`
+
+You will now have a folder structure that looks like this:
+
+```shell
+fhir-server
+- package.json
+```
+
+### Install `node-fhir-server-core`
+
+Simply run `yarn add @asymmetrik/node-fhir-server-core`.
+
+### Create an entry file and a start script
+
+Let's start by creating an `index.js` file in the root of the project and add the following code to it.
+
+```javascript
+const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+
+let config = { profiles: {}};
+let server = FHIRServer.initialize(config);
+
+server.listen(3000, () => {
+	server.logger.info('Starting the FHIR Server at localhost:3000');
+});
+```
+
+What we are doing here is loading the core library and then calling initialize on it. Internally this will setup middleware, various security features, public directory routes, error routes, and routes for FHIR resources. Then finally we tell the server to listen on port 3000 which makes the server available at `http://www.localhost:3000`.
+
+You will now have a folder structure that looks like this:
+
+```shell
+fhir-server
+- node_modules
+- index.js
+- package.json
+- yarn.lock
+```
+
+The next thing we want to do is run this file in node. Let's add a script to our `package.json`, it should look something like this:
+
+**NOTE:** You may have different values for some fields which is fine, the "scripts" block is the important part
+```json
+{
+  "name": "fhir-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@asymmetrik/node-fhir-server-core": "^1.3.0"
+  }
+}
+```
+
+Finally, run `yarn start` to start the server.
+
+If you have done everything correctly so far, you will receive the following error.
+
+> Error: No profiles configured. You must configure atleast 1 profile to run this server. Please review the README.md section on Configuring Profiles.
+
+By default, our library does not provide support for any profiles, and without a profile, what is the point to having a server. Next, let's walk you through setting up a simple patient profile. A profile corresponds to a queryable FHIR resource and we support many.
+
+### Creating a patient profile
+
+We will need to do a few things to add support for Patient resources in our server. Let's start by adding a patient service. Create a `patient.service.js` file in the root.
+
+You will now have a folder structure that looks like this:
+
+```shell
+fhir-server
+- node_modules
+- index.js
+- package.json
+- patient.service.js
+- yarn.lock
+```
+
+Add the following code to the patient service.
+
+```javascript
+module.exports.search = (args, logger) => new Promise((resolve, reject) => {
+	reject(new Error('Unable to locate patients'));
+});
+```
+
+We are going to add support for the search interaction. Each profile can support many interactions. We have some documentation on profiles and how they work in the [Profile wiki](https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profile) with more updates coming soon to cover everything. For now, let's start with a simple search.
+
+The next thing we need to do is update our config in `index.js` to tell it we want to support the patient profile.
+
+In `index.js`, add the following to the top of the file:
+
+```javascript
+const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const path = require('path');
+
+const { VERSIONS } = FHIRServer.constants;
+```
+
+and then change `let config = { profiles: {}};` to the following:
+
+```javascript
+let config = {
+	server: {},
+	logging: {
+		level: 'debug'
+	},
+	profiles: {
+		patient: {
+			service: path.posix.resolve('./patient.service.js'),
+			versions: [ VERSIONS['3_0_1'] ]
+		}
+	}
+};
+```
+
+Here we are telling the FHIR server where to locate the patient service and that we intend to support it on STU3(3.0.1 specifically). We are also enabling logging and providing a base value for server config (the server config is required at the moment but will not be in the future, for now, just give it an empty object). We are still adding documentation for all the various options you can set here so when it is available, we will add more links to it here.
+
+Now run `yarn start` one more time. You should something very similar to the following:
+
+```shell
+2019-01-08T20:56:50.563Z - info: Starting the FHIR Server at localhost:3000
+```
+
+Open [http://localhost:3000/3_0_1/metadata](http://localhost:3000/3_0_1/metadata) in your browser and you should see a capability statement resource indicating you support the Patient resource. You can also open [http://localhost:3000/3_0_1/Patient](http://localhost:3000/3_0_1/Patient) to attempt a patient query. You should see an operation outcome that looks something like this:
+
+```json
+{
+    "resourceType": "OperationOutcome",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><table border=\"0\"><tr><td style=\"font-weight: bold;\">error</td><td><pre>Unable to locate patients</pre></td></tr></table></div>"
+    },
+    "issue": [{
+        "severity": "error",
+        "code": "exception",
+        "diagnostics": "Unable to locate patients"
+    }]
+}
+```
+
+This is good as this is the error we created in the `patient.service.js`. `patient.service.js` is where you want to execute your queries and return your patient JSON. So you may need to connect to a database, query your data, and possibly even map your data back to a FHIR format if it is not already in a FHIR format.
+
+If you made it this far, thanks for sticking it out and completing the Getting Started guide. Please browse the other wiki pages for more information and feel free to file issues/questions on our [issues](https://github.com/Asymmetrik/node-fhir-server-core/issues) page.

--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -1,0 +1,217 @@
+## Overview
+The config drives the entire server.  We try to make it easy to adopt this solution by passing in which part of the server you want to use.  There are 3 main sections of the config.  
+
+#### Auth
+> NOTE: This section may change slightly as we work on some optional integrations and see what works best for the most use cases.
+
+This section of the config drives the authentication and authorization layer of the server.  If you are using SMART on FHIR we provide a [passportjs](http://www.passportjs.org/) strategy and authorization middleware you can use out of the box with just some minor configurations. We also allow you to provide your own custom passport strategy. Both authentication and authorization are disabled by default for development sake. To run them on you just need to provide a few options outlined below.
+
+Please see the [Access Control](https://github.com/Asymmetrik/node-fhir-server-core/wiki/Access-Control) wiki for a step by step guide to enable it in your application or how to add your own custom setup.
+
+#### Server
+This section of the config sets up the [Express](https://expressjs.com/) framework and certain middleware.  You can specify which port your app runs on, the cors options, and ssl support.  For more information, scroll down to the description of each property below.
+
+#### Profiles
+This section of the config sets up which version of the FHIR specification you want to support and which resource from that version you want to support.  You can support multiple versions.  The core library will automatically set up all of the routes and required parameters for each version and resource.
+
+## Configurations
+Here is an example config with all the currently supported options. See descriptions below.
+
+```javascript
+{
+	auth: {
+		type: 'auth-type',
+                strategy: {
+                        name: 'bearer',
+                        useSession: false,
+                        service: 'path/to/authentication.service.js'
+                }
+	},
+	server: {
+		port: 3000,
+		corsOptions: {
+			maxAge: 86400
+		},
+		sessionStore: null,
+		ssl: {
+			key: 'path/to/key.pem',
+			cert: 'path/to.cert.pem'
+		},
+		publicDirectory: '/path/to/public'
+	},
+	logging: {
+		level: 'debug'
+	},
+        events: {
+                auditEvent: service.writeAuditEventRecords,
+                provenance: service.writeProvenanceRecords,
+        },
+	profiles: {
+		patient: {
+			service: './patient/patient.controller',
+                        versions: [ VERSIONS.STU3 ],
+			corsOptions: {
+				// Have a different max age for all the routes in the patient profile
+				maxAge: 3600
+			}
+		},
+		observation: {
+			service: require('./observation/observation.controller'),
+                        versions: [ VERSIONS.STU3 ]
+			corsOptions: {
+				// Disable cors on this profile, maybe this is for internal use only
+				origin: false
+			}
+		}
+	}
+}
+```
+
+#### `auth.type`
+
+- **Type:** `string`
+- **Description:** The type of authentication used. Currently this is only needed to enable SMART authentication. If you want to use SMART authentication, set this value to `smart`. 
+- **Required:** false
+- **Default:** undefined
+
+#### `auth.strategy`
+
+- **Type:** `object`
+- **Description:** A Configuration object for the passport strategy.
+- **Required:** false
+- **Default:** undefined
+
+#### `auth.strategy.name`
+
+- **Type:** `string`
+- **Description:** The name of your strategy.
+- **Required:** false
+- **Default:** undefined
+
+#### `auth.strategy.useSession`
+
+- **Type:** `string`
+- **Description:** Whether or not you want `session` enabled on `passport.authenticate()`.
+- **Required:** false
+- **Default:** undefined
+
+#### `auth.strategy.service`
+
+- **Type:** `string`
+- **Description:** A relative path to a authentication service module. It currently must export a strategy property which is set to a valid [passport strategy](http://www.passportjs.org/packages/).
+- **Required:** false
+- **Default:** undefined
+
+#### `server.port`
+
+- **Type:** `number`
+- **Description:** Port the express app will listen to.
+- **Required:** Yes
+- **Default:** `none`
+
+#### `server.corsOptions`
+
+- **Type:** `object`
+- **Description:** Any default cors options you would like applied to all routes. Please see [https://github.com/expressjs/cors#configuration-options](https://github.com/expressjs/cors#configuration-options) for details. The `methods` configuration will not be honored if specified here. That is the only option controlled by `@asymmetrik/node-fhir-server-core` and cannot be overridden.
+- **Required:** No
+- **Default:** `none`
+
+#### `server.sessionStore`
+
+- **Type:** `object`
+- **Description:** Instance of an `express-session`. Depending on your back end, you can create and configure your own session store and pass it in. For example:
+
+```javascript
+const session = require('express-session');
+const expressSessionStore = session({
+	resave: true,
+	saveUninitialized: true,
+	secret: appConfig.auth.sessionSecret,
+	cookie: appConfig.auth.sessionCookie,
+	store: new MongoStore({
+		mongooseConnection: connection,
+		collection: appConfig.auth.collection
+	})
+});
+
+const fhirConfig = {
+	server: {
+		sessionStore: expressSessionStore
+	}
+}
+```
+- **Required:** No
+- **Default:** `none`
+
+#### `server.ssl.key`
+
+- **Type:** `string`
+- **Description:** Path to your private key. See [Contributor's guide](./.github/CONTRIBUTING.md#generate-self-signed-certs) for how to generate a self-signed cert for local development.
+- **Required:** No. If you want to setup express to use ssl, you need both a key and cert.
+- **Default:** `none`
+
+#### `server.ssl.cert`
+
+- **Type:** `string`
+- **Description:** Path to your certificate. See [Contributor's guide](./.github/CONTRIBUTING.md#generate-self-signed-certs) for how to generate a self-signed cert for local development.
+- **Required:** No. If you want to setup express to use ssl, you need both a key and cert.
+- **Default:** `none`
+
+#### `server.publicDirectory`
+
+- **Type:** `string`
+- **Description:** Path to your public directory. Some certificate authorities need to validate your server, for example, Let's Encrypt. You can use this to enable a public directory to serve the challenge file from `/.well-known/acme-challenge`.
+- **Required:** No.
+- **Default:** `none`
+
+#### `logging.level`
+> Currently this is the only logging configuration supported. We use Winston for logging and will eventually add support for more options.
+
+- **Type:** `string`
+- **Description:** Logging level to use for Winston. Logging level can be anything supported by Winston. See https://github.com/winstonjs/winston#using-logging-levels.
+- **Required:** No
+- **Default:** `error`
+
+#### `events.auditEvent`
+> Subscribe to incidents that create audit events.
+
+- **Type:** `function`
+- **Description:** Occasionally certain security/privacy related events occur on the server and those events need to be recorded. You can subscribe to audit events with any function that will receive an AuditEvent resource anytime these events occur. The scope of these events may increase over time so it is up to you to decide what to do with them based on their internal values.
+- **Required:** No. However we strongly advise you use this.
+- **Default:** `none`
+- **Example:**
+
+```javascript
+// In config object
+{
+	events: {
+		// This function is inlined just for the example, probably better to have in a service somewhere
+		auditEvent: function (auditEventResource) {
+			// insert the resource into your DB here
+		}
+	}
+}
+```
+
+#### `events.provenance`
+> Subscribe to incidents that create provenance resources.
+
+- **Type:** `function`
+- **Description:** Provenance resources are created when a resource changes "how it came to be". This means on updates, creates, and deletes. These are useful for tracking these kinds of changes. When the server adds write support, this will be very useful. Until then, we are not emitting these events.
+- **Required:** No. However we strongly advise you use this.
+- **Default:** `none`
+- **Example:**
+
+```javascript
+// In config object
+{
+	events: {
+		provenance: function (provenanceResource) {
+			// insert the resource into your DB here
+		}
+	}
+}
+```
+
+#### `profiles[key]`
+All profiles configurations are defined in the profiles section, [https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profiles#profile-configuration](https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profiles#profile-configuration). There are also examples of them in the [Getting Started](https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profiles#getting-started) section of the Profiles wiki page.


### PR DESCRIPTION
With the pending release of a new version and so many features being added. We decided to start relocating docs into the source code. This way they can be version specific and we do not need to make everyone an official contributor just so they can update our docs.

This PR takes several guides from our current wiki and copies them into the docs folder and then adds links to them on the main README.md file. After this is merged, I will also update the current wiki with a note saying that the wiki is being deprecated, and drop links for where to look.