### PR TITLE
Custom errors and updated documentation

### DIFF
--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -218,7 +218,7 @@ module.exports.patch = async (args, context) => {
 - **Routes:** Enables `/:base_version/[profile_name]/:id` via DELETE
 - **Example:**
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { resolveSchema, ServerError } = require('@asymmetrik/node-fhir-server-core');
 // In patient service
 module.exports.remove = async (args, context) => {
 	let OperationOutcome = require(resolveSchema(args.base_version, 'operationoutcome'));
@@ -230,7 +230,7 @@ module.exports.remove = async (args, context) => {
 		// 405 if you do not want to allow the delete
 		// 409 if you can't delete because of referential
 		// integrity or some other reason
-		let outcome = new OperationOutcome({
+		let outcome = new ServerError({
 			statusCode: 409,
 			issue: [{
 				severity: 'error',

--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -66,8 +66,7 @@ module.exports.search = async (args, context) => {
 	let results = await db.patients.find(query).toArray();
 	let patients = results.map(result => new Patient(result));
 	let entries = patients.map(patient => new BundleEntry({ resource: patient }));
-	let bundle = new Bundle({ entry: entries });
-	return bundle;
+	return new Bundle({ entry: entries });
 };
 ```
 
@@ -230,7 +229,7 @@ module.exports.remove = async (args, context) => {
 		// 405 if you do not want to allow the delete
 		// 409 if you can't delete because of referential
 		// integrity or some other reason
-		let outcome = new ServerError({
+		throw new ServerError({
 			statusCode: 409,
 			issue: [{
 				severity: 'error',
@@ -240,8 +239,6 @@ module.exports.remove = async (args, context) => {
 				}
 			}]
 		});
-		
-		throw outcome;
 	}
 
 	return;

--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -217,11 +217,9 @@ module.exports.patch = async (args, context) => {
 - **Routes:** Enables `/:base_version/[profile_name]/:id` via DELETE
 - **Example:**
 ```javascript
-const { resolveSchema, ServerError } = require('@asymmetrik/node-fhir-server-core');
+const { ServerError } = require('@asymmetrik/node-fhir-server-core');
 // In patient service
 module.exports.remove = async (args, context) => {
-	let OperationOutcome = require(resolveSchema(args.base_version, 'operationoutcome'));
-	
 	try {
 		await db.patients.remove({ _id: args.id });
 	} catch (err) {

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -104,7 +104,7 @@ fhir-server
 Add the following code to the patient service.
 
 ```javascript
-module.exports.search = async (args, logger) => {
+module.exports.search = async (args, context) => {
 	throw new Error('Unable to locate patients');
 };
 ```

--- a/docs/MIGRATION_2.0.0.md
+++ b/docs/MIGRATION_2.0.0.md
@@ -41,14 +41,14 @@ module.exports.search = async (args, context) => {
 	// You will need to build your query based on the sanitized args
 	let query = myCustomQueryBuilder(args);
 	let results = await db.patients.find(query).toArray();
+	// Cast all the results to the correct FHIR resources
 	let patients = results.filter(result => result.resourceType === 'Patient').map(result => new Patient(result));
 	let observations = results.filter(result => result.resourceType === 'Observation').map(result => new Observation(result));
 	let entries = Array.prototype.concat(
 		patients.map(patient => new BundleEntry({ resource: patient })),
 		observations.map(observation => new BundleEntry({ resource: observation }))
 	);
-	let bundle = new Bundle({ entry: entries });
-	return bundle;
+	return new Bundle({ entry: entries });
 };
 ```
 

--- a/docs/MIGRATION_2.0.0.md
+++ b/docs/MIGRATION_2.0.0.md
@@ -68,15 +68,16 @@ module.exports.searchById = async (args, context) => {
 Previously, when you threw an error in your service, we just took the error message and a status code and passed in to some utility that wrapped it in a minimal operation outcome. But what if you want to customize the operation outcome or use a different code than we had available. There was no way to do that. In version 2.0.0, since we changed how you return data in your services, you can create your own and just return it. We also allow you to add additional properties to it so you can control other things, such as the HTTP response code. For example, let's throw an error for attempting to delete a resource that other resources depend on. The spec says the HTTP status code must be a 409 in this case, for conflict. You could implement that like so:
 
 ```javascript
-const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');
+const { ServerError } = require('@asymmetrik/node-fhir-server-core');
 // In patient service
 module.exports.remove = async (args, context) => {
-	let OperationOutcome = require(resolveSchema(args.base_version, 'operationoutcome'));
 	try {
 		await db.patients.remove({ _id: args.id });
 	} catch (err) {
 		// For argument sake, assume we failed because an Observation references this patient
-		let outcome = new OperationOutcome({
+		// Express will catch this and we will wrap it in an actual operation outcome
+		// for the correct version, so make sure your JSON is formatted correctly
+		throw new ServerError({
 			// Set this to make the HTTP status code 409
 			statusCode: 409,
 			// Add any normal operation outcome stuff here

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "start": "node src/runner",
     "nodemon": "cross-env NODE_ENV=development; node src/scripts/nodemon",
     "lint": "eslint \"src/**/*.js\"",
-    "jest": "jest src",
     "test": "cross-env NODE_ENV=test; set -e; npm run lint; npm run jest;",
     "changelog": "conventional-changelog -p angular -s -r 0 -i CHANGELOG.md",
     "prettier": "prettier \"src/**/*.js\" --write",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-core",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Node FHIR Rest API Server",
   "main": "src/index",
   "author": "Asymmetrik Ltd.",
@@ -22,6 +22,7 @@
     "start": "node src/runner",
     "nodemon": "cross-env NODE_ENV=development; node src/scripts/nodemon",
     "lint": "eslint \"src/**/*.js\"",
+    "jest": "jest src",
     "test": "cross-env NODE_ENV=test; set -e; npm run lint; npm run jest;",
     "changelog": "conventional-changelog -p angular -s -r 0 -i CHANGELOG.md",
     "prettier": "prettier \"src/**/*.js\" --write",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const { resolveSchema } = require('./server/utils/resolve.utils');
+const ServerError = require('./server/utils/server.error');
 const winston = require('./server/winston.js');
 const Server = require('./server/server');
 const constants = require('./constants');
@@ -12,6 +13,12 @@ module.exports = {
 	 * @description Export constants so users can have access to these
 	 */
 	constants: constants,
+
+	/**
+	 * @description Export Server Error class for people to throw from services
+	 * This will in turn generate an operation outcome
+	 */
+	ServerError: ServerError,
 
 	/**
 	 * @description Export the server class so someone can build it themselves. This gives them

--- a/src/scripts/nodemon.js
+++ b/src/scripts/nodemon.js
@@ -1,5 +1,7 @@
+const winston = require('../server/winston.js');
 const nodemon = require('nodemon');
-const logger = require('../server/winston')({ level: 'debug' });
+
+let logger = winston.get('default');
 
 nodemon({
 	ignore: ['node_modules'],

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,5 +1,6 @@
 const { resolveSchema } = require('./utils/resolve.utils.js');
 const deprecate = require('./utils/deprecation.notice.js');
+const ServerError = require('./utils/server.error.js');
 const invariant = require('./utils/invariant.js');
 const { VERSIONS } = require('../constants.js');
 const compression = require('compression');
@@ -239,6 +240,9 @@ class Server {
 			if (err && err.resourceType === OperationOutcome.resourceType) {
 				let status = err.statusCode || 500;
 				res.status(status).json(err);
+			} else if (err instanceof ServerError) {
+				let status = err.statusCode || 500;
+				res.status(status).json(new OperationOutcome(err));
 			} else if (err) {
 				let error = new OperationOutcome({
 					statusCode: 500,

--- a/src/server/service.mock.js
+++ b/src/server/service.mock.js
@@ -1,73 +1,77 @@
+const ServerError = require('./utils/server.error.js');
 const { container } = require('./winston.js');
 
 let logger = container.get('default');
 
-module.exports.search = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'search'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+const errorDetails = message => ({
+	statusCode: 500,
+	issue: [
+		{
+			severity: 'error',
+			code: 'internal',
+			details: {
+				text: `Unexpected: ${message}`,
+			},
+		},
+	]
+});
 
-module.exports.searchByVersionId = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'searchByVersionId'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.search = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'search'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.searchById = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'searchById'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.searchByVersionId = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'searchByVersionId'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.create = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'create'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.searchById = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'searchById'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.update = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'update'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.create = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'create'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.remove = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'remove'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.update = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'update'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.patch = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'patch'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.remove = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'remove'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.history = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'history'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.patch = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'patch'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.historyById = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'historyById'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.history = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'history'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
 
-module.exports.expandById = (_args, _context) =>
-	new Promise((resolve, reject) => {
-		let message = "Calling mock service. Did you forget to implement 'expandById'.";
-		logger.info(message);
-		reject(new Error(message));
-	});
+module.exports.historyById = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'historyById'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};
+
+module.exports.expandById = async (_args, _context) => {
+	let message = "Calling mock service. Did you forget to implement 'expandById'.";
+	logger.info(message);
+	throw new ServerError(message, errorDetails(message));
+};

--- a/src/server/utils/server.error.js
+++ b/src/server/utils/server.error.js
@@ -1,0 +1,26 @@
+/**
+ * @name exports
+ * @static
+ * @summary Error class for throwing errors from services
+ * @class ServerError
+ */
+module.exports = class ServerError extends Error {
+
+	constructor (message, options) {
+		super(message);
+
+		// Make message enumerable
+		Object.defineProperty(this, 'message', {
+			enumerable: true
+		});
+
+		// Keep stack trace for V8
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, ServerError);
+		}
+
+		// Mixin any additional options
+		Object.assign(this, options);
+	}
+
+};

--- a/src/server/utils/server.error.test.js
+++ b/src/server/utils/server.error.test.js
@@ -1,0 +1,54 @@
+const ServerError = require('./server.error.js');
+
+describe('ServerError', () => {
+	test('should be instance of Error and ServerError', () => {
+		let error = new ServerError('Foobar');
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(ServerError);
+	});
+
+	test('should mixin any additional custom properties', () => {
+		let error = new ServerError('Foobar', {
+			statusCode: 409,
+			issue: [{
+				foo: 'bar'
+			}]
+		});
+
+		expect(error.message).toBe('Foobar');
+		expect(error.statusCode).toBe(409);
+		expect(error.issue).toHaveLength(1);
+		expect(error.issue[0].foo).toBe('bar');
+	});
+
+	test('should be able to be passed directly to other classes', () => {
+		let error = new ServerError('Foobar', {
+			statusCode: 409,
+			issue: [{
+				foo: 'bar'
+			}]
+		});
+
+		// This mimics the concept of a resource we generate
+		class Operation {
+			constructor (options) {
+				Object.assign(this, options);
+			}
+
+			toJSON() {
+				return {
+					statusCode: this.statusCode,
+					message: this.message
+				};
+			}
+		}
+
+		let operation = new Operation(error);
+		let json = operation.toJSON();
+
+		expect(json.statusCode).toBe(409);
+		expect(json.message).toBe('Foobar');
+		expect(json.issue).toBeUndefined();
+	});
+});


### PR DESCRIPTION
This PR adds updated documentation to correctly show how to handle custom errors going forward. We also exposed a new error class that can be used for the custom errors that has the following API, `class ServerError(message: string, properties: object)`. This makes it very flexible in the sense it extends error so it is still a native JS error, and it allows you to pass a lot of extra properties in along with it. It accepts a `statusCode` for customizing the HTTP response code, and any properties that belong to any version of operation outcome. These properties will just be passed into an operation outcome constructor so you can set whatever you like.

This PR also does not remove previous logic, so there are no breaking changes. Below are all the ways custom errors can be created inside any of your provided services, with the first two being the preferred ways of handling it (example's will just use a search service from a patient class).

```javascript
const { ServerError } = require('@asymmetrik/node-fhir-server-core');

// Preferred way with async
module.exports.search = async (args, context) => {
  // throw with async
  throw new ServerError({
    statusCode: 500,
    issue: [{
      severity: 'error',
      code: 'internal',
      details: {
        text: 'Oops, something went wrong'
      }
    }]
  });
};

// Preferred way with promises
module.exports.search = (args, context) => new Promise((resolve, reject) => {
  // reject with promises
  reject(new ServerError({
    statusCode: 500,
    issue: [{
      severity: 'error',
      code: 'internal',
      details: {
        text: 'Oops, something went wrong'
      }
    }]
  }));
});

// Old way with async, still valid but not preferred
const { resolveSchema } = require('@asymmetrik/node-fhir-server-core');

module.exports.search = async (args, context) => {
  let OperationOutcome = require(resolveSchema(args.base_version, 'operationoutcome'));
  // OperationOutcome is not technically an error, so type systems,
  // like TypeScript or Flow will not like this
  throw new OperationOutcome({
    statusCode: 500,
    issue: [{
      severity: 'error',
      code: 'internal',
      details: {
        text: 'Oops, something went wrong'
      }
    }]
  })
};

// Old way with promises, still valid but not preferred
module.exports.search = (args, context) => new Promise((resolve, reject) => {
    let OperationOutcome = require(resolveSchema(args.base_version, 'operationoutcome'));
  // reject with promises
  reject(new OperationOutcome({
    statusCode: 500,
    issue: [{
      severity: 'error',
      code: 'internal',
      details: {
        text: 'Oops, something went wrong'
      }
    }]
  }));
});

// async error, will result in a internal server error with code 500
module.exports.search = async (args, context) => {
  // Still returns an operation outcome with just this message and a 500
  throw new Error('Oops, something went wrong');
};

// promise error, will result in a internal server error with code 500
module.exports.search = (args, context) => new Promise((resolve, reject) => {
  reject(new Error('Oops, something went wrong'));
});
```