### PR TITLE
Hotfix: Missing message in docs for new Error class

### DIFF
--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -227,7 +227,7 @@ module.exports.remove = async (args, context) => {
 		// 405 if you do not want to allow the delete
 		// 409 if you can't delete because of referential
 		// integrity or some other reason
-		throw new ServerError({
+		throw new ServerError(err.message, {
 			statusCode: 409,
 			issue: [{
 				severity: 'error',

--- a/docs/MIGRATION_2.0.0.md
+++ b/docs/MIGRATION_2.0.0.md
@@ -77,16 +77,15 @@ module.exports.remove = async (args, context) => {
 		// For argument sake, assume we failed because an Observation references this patient
 		// Express will catch this and we will wrap it in an actual operation outcome
 		// for the correct version, so make sure your JSON is formatted correctly
-		throw new ServerError({
+		let message = 'Failed to delete patient because Resource XYZ depends on it.';
+		throw new ServerError(message, {
 			// Set this to make the HTTP status code 409
 			statusCode: 409,
 			// Add any normal operation outcome stuff here
 			issue: [{
 				severity: 'error',
 				code: 'internal',
-				details: {
-					text: 'Failed to delete patient because Resource XYZ depends on it.'
-				}
+				details: { text: message }
 			}]
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-core",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Node FHIR Rest API Server",
   "main": "src/index",
   "author": "Asymmetrik Ltd.",


### PR DESCRIPTION
This PR just adds the message to the ServerError class examples

Commits: 

fix: documentation error, error class missing message argument