### PR TITLE
chore: Fix documentation typos and grammar

### DIFF
--- a/docs/ConfiguringProfiles.md
+++ b/docs/ConfiguringProfiles.md
@@ -264,4 +264,4 @@ module.exports.remove = async (args, context) => {
 ```
 
 ## Arguments
-Each resource supports the arguments defined by the specification for its own version. You can either review the official FHIR documentation, or you can look in the [resources](../src/server/resources) directory of this project. Each `version` folder represents a version we support, and in each  version folder is a `parameters` folder which defines the parameters for each resource. When an API endpoint is hit, each resource will allow its own arguments and any inherited arguments from parent resources such as resource and/or domain resource.
+Each resource supports the arguments defined by the specification for its own version. You can either review the official FHIR documentation, or you can look in the [resources](../src/server/resources) directory of this project. Each `version` folder represents a version we support, and in each  version folder there is a `parameters` folder which defines the parameters for each resource. When an API endpoint is hit, each resource will allow its own arguments and any inherited arguments from parent resources.

--- a/docs/CustomCapability.md
+++ b/docs/CustomCapability.md
@@ -7,16 +7,17 @@ The capability statement now allows for the configuration of what information ge
 ### Creating a Statement Generator
 You can include this code where you define your Asymmetrik Server configurations or include it in another file and require it in. For this example, we will go with the latter option.
 
-First, we're going to require in the Asymmetrik FHIR Server source code. This will allow us to have access to the class that is responsible for generating the Capability Statement so that we can create our own.
+First, we're going to require the Asymmetrik FHIR Server source code. This will allow us to have access to the class that is responsible for generating the Capability Statement so that we can create our own.
 
 ```javascript
-// require in the Asymmetrik FHIR Server
+// require the Asymmetrik FHIR Server
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
 ```
-
-Then we'll create a function that will require in the `CapabilityStatement` class, and return a new instance that contains your information. Please make sure you remain compliant with the FHIR specification.
+Then we'll create a function that will require the `CapabilityStatement` class, and return a new instance that contains your information. Please make sure you remain compliant with the FHIR specification.
 
 ```javascript
+const base_version = '4_0_0'
+
 let customCapabilityStatement = resources => {
   let CapabilityStatement = require(FHIRServer.resolveSchema(base_version, 'CapabilityStatement'));
 
@@ -98,7 +99,7 @@ module.exports.generateStatements = (args) => {
 Now that we've built out our Statement Generator and have customized the Capability Statement info to our liking, we can add it to our configuration by doing the following: 
 ```javascript
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
-const generateCapabilityStatement = require('path to your statement generator file').generateStatements; // require in the statement generator file
+const generateCapabilityStatement = require('path to your statement generator file').generateStatements; // require the statement generator file
 
 let config = {
   ...other config options,

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -145,7 +145,7 @@ let config = {
 
 Here we are telling the FHIR server where to locate the patient service and that we intend to support it on R4 (`4.0.0` specifically). See the [server configuration docs](./ServerConfiguration.md) for more configuration options.
 
-Now run `yarn start` one more time. You should something very similar to the following:
+Now run `yarn start` one more time. You should see something very similar to the following:
 
 ```shell
 2019-01-08T20:56:50.563Z - info: Starting the FHIR Server at localhost:3000

--- a/docs/MIGRATION_2.0.0.md
+++ b/docs/MIGRATION_2.0.0.md
@@ -28,7 +28,7 @@ We think this will simplify things a lot for developers on both sides, contribut
 
 ### Return types
 
-One major change for version `2.0.0` is how your services returned resources. Everything before `2.0.0` returned JSON and only JSON. Bundles would attempt to set correct properties based on a variety of things, but ultimately, would not cast resources because it did not want to assume all resources were the same type. Doing the casting and crafting these responses made the response utils very ugly and do more than they really needed to do. Response utils have since moved to an external package, which you can find at [fhir-response-util](https://github.com/Asymmetrik/phx-tools/tree/master/packages/fhir-response-util). They are now very simple to work with and easier to modify in the future.
+One major change for version `2.0.0` is how your services returned resources. Everything before `2.0.0` returned JSON and only JSON. Bundles would attempt to set correct properties based on a variety of things, but ultimately, would not cast resources because it did not want to assume all resources were the same type. Doing the casting and crafting these responses made the response utils very ugly and they were doing more than they really needed to do. Response utils have since moved to an external package, which you can find at [fhir-response-util](https://github.com/Asymmetrik/phx-tools/tree/master/packages/fhir-response-util). They are now very simple to work with and easier to modify in the future.
 
 What this means for developers is that they will now need to be explicit when returning data from a service and use the schemas we are providing.
  


### PR DESCRIPTION
I found a few typos and grammar mistakes.