### PR TITLE
7opf sof custom scope key

### DIFF
--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -21,6 +21,7 @@ Here is an example config with all the currently supported options. See descript
 {
 	auth: {
 		type: 'auth-type',
+		customScopeKey: 'custom',
     strategy: {
 	    name: 'bearer',
 	    useSession: false,
@@ -74,6 +75,13 @@ Here is an example config with all the currently supported options. See descript
 - **Description:** The type of authentication used. Currently this is only needed to enable SMART authentication. If you want to use SMART authentication, set this value to `smart`. 
 - **Required:** false
 - **Default:** undefined
+
+#### `auth.customScopeKey`
+
+- **Type:** `string`
+- **Description:** Specify the customScopeKey option to use a custom claim instead of the scope. 
+- **Required:** false
+- **Default:** `'scope'`
 
 #### `auth.strategy`
 

--- a/src/server/middleware/sof-scope.middleware.js
+++ b/src/server/middleware/sof-scope.middleware.js
@@ -36,8 +36,8 @@ function deriveActionFromInteraction(interaction) {
  * @param {Object} user
  * @return {Array<String>} scopes assigned to a particular user
  */
-function parseScopes(user = {}) {
-	return typeof user.scope === 'string' ? user.scope.split(/[, ]/) : [];
+function parseScopes(user = {}, scopeKey) {
+	return typeof user[scopeKey] === 'string' ? user[scopeKey].split(/[, ]/) : [];
 }
 
 /**
@@ -62,7 +62,7 @@ module.exports = function sofScopeCheckMiddleware(options = {}) {
 		// name is lowercased, we want upper, foo -> Foo
 		let resource = name.slice(0, 1).toUpperCase() + name.slice(1);
 		let action = deriveActionFromInteraction(route.interaction);
-		let scopes = parseScopes(req && req.user);
+		let scopes = parseScopes(req && req.user, auth.customScopeKey || 'scope');
 		// Check if they have permission
 		let { error } = scopeChecker(resource, action, scopes);
 


### PR DESCRIPTION
allows configuration of a custom scope key in sof scope middleware for tokens that have permissions in a different claim (e.g. permissions claim). Updated docs too.