### PR TITLE
7opf cors preflight bug

### DIFF
--- a/src/server/router.js
+++ b/src/server/router.js
@@ -191,7 +191,7 @@ function enableResourceRoutes(app, config, corsDefaults) {
 
 			// Calculate the cors setting we want for this route
 			let corsOptions = Object.assign({}, corsDefaults, profile.corsOptions, {
-				methods: [corsDefaults.methods || route.type.toUpperCase()],
+				methods: corsDefaults.methods || [route.type.toUpperCase()],
 			});
 
 			// Define the arguments based on the interactions

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -191,7 +191,7 @@ function enableResourceRoutes(app, config, corsDefaults) {
 
 			// Calculate the cors setting we want for this route
 			let corsOptions = Object.assign({}, corsDefaults, profile.corsOptions, {
-				methods: corsDefaults.methods || [route.type.toUpperCase()],
+				methods: [route.type.toUpperCase()],
 			});
 
 			// Define the arguments based on the interactions


### PR DESCRIPTION
`corsOptions` in `enableResourceRoutes` gets set incorrectly and according to the docs, shouldn't be possible for package users to influence the methods config.