### PR TITLE
#206 updated timing schema to use correct repeat element

### DIFF
--- a/src/server/resources/1_0_2/schemas/timing.js
+++ b/src/server/resources/1_0_2/schemas/timing.js
@@ -80,8 +80,8 @@ module.exports = class Timing {
 					return;
 				}
 
-				let Element = require('./element.js');
-				this.__data.repeat = new Element(value);
+				let TimingRepeat = require('./timingrepeat.js');
+				this.__data.repeat = new TimingRepeat(value);
 			},
 		});
 		// valueSetReference: http://hl7.org/fhir/ValueSet/timing-abbreviation

--- a/src/server/resources/3_0_1/schemas/timing.js
+++ b/src/server/resources/3_0_1/schemas/timing.js
@@ -80,8 +80,8 @@ module.exports = class Timing {
 					return;
 				}
 
-				let Element = require('./element.js');
-				this.__data.repeat = new Element(value);
+				let TimingRepeat = require('./timingrepeat.js');
+				this.__data.repeat = new TimingRepeat(value);
 			},
 		});
 		// valueSetReference: http://hl7.org/fhir/ValueSet/timing-abbreviation

--- a/src/server/resources/4_0_0/schemas/timing.js
+++ b/src/server/resources/4_0_0/schemas/timing.js
@@ -95,8 +95,8 @@ module.exports = class Timing {
 					return;
 				}
 
-				let Element = require('./element.js');
-				this.__data.repeat = new Element(value);
+				let TimingRepeat = require('./timingrepeat.js');
+				this.__data.repeat = new TimingRepeat(value);
 			},
 		});
 


### PR DESCRIPTION
If I remember correctly, the schemas are generated by something else. Can we merge this if it can't be corrected quickly?