### PR TITLE
fixes reference to doseAndRate schema

### DIFF
--- a/src/server/resources/4_0_0/schemas/dosage.js
+++ b/src/server/resources/4_0_0/schemas/dosage.js
@@ -250,8 +250,8 @@ module.exports = class Dosage {
 					return;
 				}
 
-				let Element = require('./element.js');
-				this.__data.doseAndRate = Array.isArray(value) ? value.map(v => new Element(v)) : [new Element(value)];
+				let DosageDoseAndRate = require('./dosagedoseandrate.js');
+				this.__data.doseAndRate = Array.isArray(value) ? value.map(v => new DosageDoseAndRate(v)) : [new DosageDoseAndRate(value)];
 			},
 		});
 


### PR DESCRIPTION
Previously, the _dosage_ schema was defining doseAndRate as an Element, which would output an array with empty objects when returning Dose and Rate information because the _element_ schema only accepts **id** and **extension**. The fix here swaps out the element schema for the correct _dosagedoseandrate_ schema so that the data gets displayed. 