### PR TITLE
fixed not work enableBaseRoute(router.js): syntax error

### DIFF
--- a/packages/node-fhir-server-core/src/server/router.js
+++ b/packages/node-fhir-server-core/src/server/router.js
@@ -329,8 +329,8 @@ function enableResourceRoutes(app, config, corsDefaults) {
 function enableBaseRoute(app, config, corsDefaults) {
   // Determine which versions need a base endpoint, we need to loop through
   // all the configured profiles and find all the uniquely provided versions
-  let routes = require('./base/base.config');
-  for (let i; routes.length; i++) {
+  let routes = require('./base/base.config').routes;
+  for (let i = 0; i < routes.length; i++) {
     let versionValidationConfiguration = {
       versions: getAllConfiguredVersions(config.profiles),
     };


### PR DESCRIPTION
fixed syntax error: export module, for init ...